### PR TITLE
[Issue1] Fix undefined reference to 'Nokogiri_wrap_xml_document'

### DIFF
--- a/ext/nokogumboc/extconf.rb
+++ b/ext/nokogumboc/extconf.rb
@@ -19,6 +19,9 @@ if have_library('xml2', 'xmlNewDoc')
 
     # if found, enable direct calls to Nokogiri (and libxml2)
     $CFLAGS += ' -DNGLIB' if find_header('nokogiri.h', nokogiri_ext)
+
+    # link to the library to prevent: nokogumbo.c:(.text+0x26a): undefined reference to `Nokogiri_wrap_xml_document'
+    $LDFLAGS += " -L#{nokogiri_ext} -l:nokogiri.so"
   end
 end
 


### PR DESCRIPTION
Added explicit link to avoid the undefined reference in the build on some platforms like Gentoo

To test, use branch issue1

```
git clone --recursive https://github.com/krutten/nokogumbo.git
git checkout issue1
cd nokogumbo
bundle install
rake gem
gem install pkg/nokogumbo*.gem
```

Tested on Gentoo with GCC 4.5.4
