### PR TITLE
Revert 37b8bcf4 to unbreak nokogumbo on OS X.

### DIFF
--- a/ext/nokogumboc/extconf.rb
+++ b/ext/nokogumboc/extconf.rb
@@ -19,9 +19,6 @@ if have_library('xml2', 'xmlNewDoc')
 
     # if found, enable direct calls to Nokogiri (and libxml2)
     $CFLAGS += ' -DNGLIB' if find_header('nokogiri.h', nokogiri_ext)
-
-    # link to the library to prevent: nokogumbo.c:(.text+0x26a): undefined reference to `Nokogiri_wrap_xml_document'
-    $LDFLAGS += " -L#{nokogiri_ext} -l:nokogiri.so"
   end
 end
 


### PR DESCRIPTION
This removes the change introduced in #5, which prevents nokogumbo from compiling on OS X.

If I knew more about native extensions I'd try to unbreak OS X while preserving the original fix, but unfortunately I don't. Sorry.
