### PR TITLE
Refine `nokogiri_lib` to cope with other gems with lib/nokogiri folders

### DIFF
--- a/ext/nokogumboc/extconf.rb
+++ b/ext/nokogumboc/extconf.rb
@@ -7,8 +7,9 @@ if have_library('xml2', 'xmlNewDoc')
 
   # nokogiri configuration from gem install
   nokogiri_lib = Gem.find_files('nokogiri').
-    select { |name| name.include? 'lib/nokogiri' }.
-    sort_by {|name| name[/nokogiri-([\d.]+)/,1].split('.').map(&:to_i)}.last
+    sort_by { |name|
+      name.match(%r{gems/nokogiri-([\d.]+)/lib/nokogiri}) ? Regexp.last_match[1].split('.').map(&:to_i) : [0, 0, 0]
+    }.last
   if nokogiri_lib
     nokogiri_ext = nokogiri_lib.sub(%r(lib/nokogiri(.rb)?$), 'ext/nokogiri')
 


### PR DESCRIPTION
I have a project which includes code from a gem that extends nokogiri, that code lives in `lib/nokogiri/`, which was incorrectly being matched & treated like an installed nokogiri release in `extconf.rb`.

I've altered the extconf script to continue doing what it was while fixing this specific issue.
