### PR TITLE
Build with and without libxml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,10 @@ rvm:
   - 2.0.0
   - 2.1.2
   - ruby-head
+env:
+  - WITH_LIBXML=true
+  - WITH_LIBXML=false
+before_script: |
+  if [ "$WITH_LIBXML" == "false" ]; then
+    sudo apt-get remove libxml2-dev
+  fi


### PR DESCRIPTION
When debugging #34, I came up with this Travis CI config to make it easier to reproduce compilation issues in environments both with and without libxml. Hopefully you find this helpful to avoid future build issues.