### PR TITLE
allow charset including quote

### DIFF
--- a/lib/nokogumbo.rb
+++ b/lib/nokogumbo.rb
@@ -151,7 +151,7 @@ module Nokogiri
 
         # look for a charset in a content-encoding header
         if content_type
-          encoding ||= content_type[/charset=(.*?)($|\s|;)/i, 1]
+          encoding ||= content_type[/charset=["']?(.*?)($|["';\s])/i, 1]
         end
 
         # look for a charset in a meta tag in the first 1024 bytes


### PR DESCRIPTION
Some site has quote at Content-type header's charset
e.g.) `charset='utf-8'`
It is invalid but exists in reality. So please allow this