### PR TITLE
Include comment nodes that are siblings of html.

### DIFF
--- a/test-nokogumbo.rb
+++ b/test-nokogumbo.rb
@@ -120,6 +120,11 @@ class TestNokogumbo < Minitest::Test
     assert_equal "record", template.at('td')['class']
   end
 
+  def test_root_comments
+    doc = Nokogiri::HTML5("<!DOCTYPE html><!-- start --><html></html><!-- -->")
+    assert_equal ["html", "comment", "html", "comment"], doc.children.map(&:name)
+  end
+
 private
 
   def buffer


### PR DESCRIPTION
The HTML

```
<!DOCTYPE html>
<!-- start comment --><html>
</html><!-- end comment -->
```

should produce an XML tree with DTD, comment, html, and comment nodes.
Previously the comment nodes were parsed by Gumbo but not inserted into the
`xmlDoc`.