### PR TITLE
Expose Gumbo parse errors to Nokogiri document.

### DIFF
--- a/test-nokogumbo.rb
+++ b/test-nokogumbo.rb
@@ -125,6 +125,13 @@ class TestNokogumbo < Minitest::Test
     assert_equal ["html", "comment", "html", "comment"], doc.children.map(&:name)
   end
 
+  def test_parse_errors
+    doc = Nokogiri::HTML5("<!DOCTYPE html><html><!-- -- --></a>")
+    assert_equal doc.errors.length, 2
+    doc = Nokogiri::HTML5("<!DOCTYPE html><html>")
+    assert_empty doc.errors
+  end
+
 private
 
   def buffer


### PR DESCRIPTION
Use the internal Gumbo error API to get error parse error information. Expose
this to Ruby by crafting an array of `Nokogiri::XML::SyntaxError` objects filled
in with a variety of information, including column and line information. These
are stored in the document's `@errors` instance variable.

Note that since the HTML state machine completely specifies what to do on
every parse error, no error is fatal.