### PR TITLE
Use standard Apache-2.0 license identifier

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -51,7 +51,7 @@ SPEC = Gem::Specification.new do |gem|
   gem.extensions = 'ext/nokogumboc/extconf.rb'
   gem.author = 'Sam Ruby'
   gem.add_dependency 'nokogiri'
-  gem.license = 'Apache 2.0'
+  gem.license = 'Apache-2.0'
   gem.description = %q(
     Nokogumbo allows a Ruby program to invoke the Gumbo HTML5 parser and
     access the result as a Nokogiri parsed document.).strip.gsub(/\s+/, ' ')


### PR DESCRIPTION
per https://spdx.org/licenses/

Fixes RubyGems warning:

```
WARNING:  license value 'Apache 2.0' is invalid.  Use a license
identifier from
http://spdx.org/licenses or 'Nonstandard' for a nonstandard license.
Did you mean 'Apache-2.0'?
```