### PR TITLE
Work around a bug in gumbo-parser's error printing.

### DIFF
--- a/ext/nokogumboc/nokogumbo.c
+++ b/ext/nokogumboc/nokogumbo.c
@@ -227,6 +227,13 @@ static VALUE parse(VALUE self, VALUE string) {
     for (int i=0; i < errors->length; i++) {
       GumboError *err = errors->data[i];
       gumbo_string_buffer_clear(&parser, &msg);
+      // Work around bug in gumbo_caret_diagnostic_to_string.
+      // See https://github.com/google/gumbo-parser/pull/371
+      // The bug occurs when the error starts with a newline (unless it's the
+      // first character in the input--but that shouldn't cause an error in
+      // the first place.
+      if (*err->original_text == '\n' && err->original_text != input)
+        --err->original_text;
       gumbo_caret_diagnostic_to_string(&parser, err, input, &msg);
       VALUE err_str = rb_str_new(msg.data, msg.length);
       VALUE syntax_error = rb_class_new_instance(1, &err_str, XMLSyntaxError);

--- a/test-nokogumbo.rb
+++ b/test-nokogumbo.rb
@@ -132,6 +132,11 @@ class TestNokogumbo < Minitest::Test
     assert_empty doc.errors
   end
 
+  def test_parse_fragment_errors
+    doc = Nokogiri::HTML5.fragment("<\r\n")
+    refute_empty doc.errors
+  end
+
 private
 
   def buffer


### PR DESCRIPTION
gumbo tries to add the line that contains the error to the error
message. If the error starts with a newline, for example, if the input
is the string "<\n", then due to a bug, gumbo produces a `(ptrdiff_t)-1`
size string "starting" at the byte after the newline.

This patch modifies the `GumboError` to point one byte earlier if it
points at a newline (that isn't the first character of the input).