### PR TITLE
Remove testing unsupported versions of Ruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: ruby
 rvm: # http://rubies.travis-ci.org/
-  - 1.9.3
-  - 2.0.0
   - 2.1.10
   - 2.2.6
   - 2.3.3


### PR DESCRIPTION
Nokogiri requires Ruby version >= 2.1.0.