### PR TITLE
Fix nokogiri rpath build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,29 @@
 language: ruby
+# Start OSX builds before Linux, because they take longer.
+os:
+  - osx
+  - linux
 rvm: # http://rubies.travis-ci.org/
-  - 1.9.3
-  - 2.0.0
-  - 2.1.10
-  - 2.2.6
-  - 2.3.3
-  - 2.4.0
+  - 1.9
+  - 2.0
+  - 2.1
+  - 2.2
+  - 2.3
+  - 2.4
+matrix:
+  exclude:
+    - os: osx
+      rvm: 1.9
+    - os: osx
+      rvm: 2.0
+    - os: osx
+      env: WITH_LIBXML=false V=1
 env:
-  - WITH_LIBXML=true
-  - WITH_LIBXML=false
+  - WITH_LIBXML=true V=1
+  - WITH_LIBXML=false V=1
 before_script: |
   if [ "$WITH_LIBXML" == "false" ]; then
     sudo apt-get remove libxml2-dev
   fi
+sudo: required
+cache: bundler

--- a/Rakefile
+++ b/Rakefile
@@ -16,7 +16,12 @@ DLEXT = RbConfig::CONFIG['DLEXT']
 EXT = 'ext/nokogumboc'
 file "#{EXT}/nokogumboc.#{DLEXT}" => ["#{EXT}/Makefile","#{EXT}/nokogumbo.c"] do
   Dir.chdir 'ext/nokogumboc' do
-    sh 'make'
+    # Make it possible to get quiet or verbose Make
+    job = %w{make}
+    %w{V Q}.each do |k|
+      job << "#{k}="+ENV[k] if ENV[k]
+    end
+    sh job.join(' ')
   end
 end
 

--- a/ext/nokogumboc/extconf.rb
+++ b/ext/nokogumboc/extconf.rb
@@ -1,16 +1,18 @@
 require 'mkmf'
-$CFLAGS += " -std=c99"
+$CFLAGS += ' -std=c99'
 
-if have_library('xml2', 'xmlNewDoc') 
+if have_library('xml2', 'xmlNewDoc')
   # libxml2 libraries from http://www.xmlsoft.org/
   pkg_config('libxml-2.0')
 
   # nokogiri configuration from gem install
-  nokogiri_lib = Gem.find_files('nokogiri').
-    select { |name| name.match(%r{gems/nokogiri-([\d.]+)/lib/nokogiri}) }.
-    sort_by {|name| name[/nokogiri-([\d.]+)/,1].split('.').map(&:to_i)}.last
+  nokogiri_lib = Gem
+                 .find_files('nokogiri')
+                 .select { |name| name.match(%r{gems/nokogiri-([\d.]+)/lib/nokogiri}) }
+                 .sort_by { |name| name[/nokogiri-([\d.]+)/, 1].split('.').map(&:to_i) }
+                 .last
   if nokogiri_lib
-    nokogiri_ext = nokogiri_lib.sub(%r(lib/nokogiri(.rb)?$), 'ext/nokogiri')
+    nokogiri_ext = nokogiri_lib.sub(%r{lib/nokogiri(.rb)?$}, 'ext/nokogiri')
 
     # if that doesn't work, try workarounds found in Nokogiri's extconf
     unless find_header('nokogiri.h', nokogiri_ext)
@@ -19,6 +21,28 @@ if have_library('xml2', 'xmlNewDoc')
 
     # if found, enable direct calls to Nokogiri (and libxml2)
     $CFLAGS += ' -DNGLIB' if find_header('nokogiri.h', nokogiri_ext)
+
+    # If libnokogiri is not on the build path, we need to add it.
+    unless have_library('nokogiri', 'Nokogiri_wrap_xml_document')
+      nokogiri_libfile = 'nokogiri.' + RbConfig::CONFIG['DLEXT']
+      nokogiri_libpath = File.join(nokogiri_ext, nokogiri_libfile)
+      if File.exist? nokogiri_libpath
+        $LDFLAGS += " -Wl,-rpath #{nokogiri_ext} -L#{nokogiri_ext} "
+        # GNU ld:
+        # '-lFOO' => looks for a file named 'libFOO.a' or 'libFOO.so*'
+        # '-l:FOO' => looks for a file named exactly 'FOO'
+        # OSX/Mach ld:
+        # - '-l:' is not supported.
+        # - Only links '.dylib', not '.bundle'
+        #
+        # Nokogiri does NOT have a lib prefix, so we need to be creative in
+        # testing; and might have either .dylib or .bundle suffixes.
+        $LIBS += ' ' + nokogiri_libpath + ' ' \
+          if %w(so dylib).include? RbConfig::CONFIG['DLEXT']
+      else
+        puts 'WARNING! Could not find Nokogiri_wrap_xml_document symbol; build might fail.'
+      end
+    end
   end
 end
 
@@ -28,12 +52,12 @@ unless have_library('gumbo', 'gumbo_parse')
   unless File.exist? "#{rakehome}/ext/nokogumboc/gumbo.h"
     require 'fileutils'
     FileUtils.cp Dir["#{rakehome}/gumbo-parser/src/*"],
-      "#{rakehome}/ext/nokogumboc"
+                 "#{rakehome}/ext/nokogumboc"
 
     case RbConfig::CONFIG['target_os']
     when 'mingw32', /mswin/
       FileUtils.cp Dir["#{rakehome}/gumbo-parser/visualc/include/*"],
-        "#{rakehome}/ext/nokogumboc"
+                   "#{rakehome}/ext/nokogumboc"
     end
 
     $srcs = $objs = nil


### PR DESCRIPTION
This is a revisit of the earlier Gentoo fix, but is relevant for any
system that might be strict on linking paths and doesn't have the
nokogiri lib in the ld.so search path.

Firstly, the initial linking will fail. Simply fixing that is NOT
sufficent on it's own (you can see with ldd .../nokogumbo.so), as it
will not update the RPATH in the ELF output, and that needs to also be
specified.

We conditionally wrap this using have_library, so it's only attempted if
actually needed.

Just -L + -l leads to:
/usr/lib64/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require': nokogiri.so: cannot open shared object file: No such file or directory - .../nokogumbo/ext/nokogumboc/nokogumboc.so (LoadError)

$ ldd ./ext/nokogumboc/nokogumboc.so
  linux-vdso.so.1 (0x00007ffd2db70000)
  nokogiri.so => not found
  libruby21.so.2.1 => /usr/lib64/libruby21.so.2.1 (0x00007f565c4e7000)
  libxml2.so.2 => /usr/lib64/libxml2.so.2 (0x00007f565c17d000)
  ...

With -L + -l + -Wl,-rpath, it works, and ldd output:
$ ldd ext/nokogumboc/nokogumboc.so
  linux-vdso.so.1 (0x00007ffd55f7b000)
  nokogiri.so => /usr/lib64/ruby/gems/2.1.0/gems/nokogiri-1.6.8.1/ext/nokogiri/nokogiri.so (0x00007f823ab55000)
  libruby21.so.2.1 => /usr/lib64/libruby21.so.2.1 (0x00007f823a656000)
  libxml2.so.2 => /usr/lib64/libxml2.so.2 (0x00007f823a2ec000)

Fixes: https://github.com/rubys/nokogumbo/issues/40
Fixes: https://github.com/rubys/nokogumbo/pull/47
Signed-off-by: Robin H. Johnson <robbat2@gentoo.org>