### PR TITLE
Import gumbo internal headers if needed.

### DIFF
--- a/ext/nokogumboc/extconf.rb
+++ b/ext/nokogumboc/extconf.rb
@@ -40,4 +40,21 @@ unless have_library('gumbo', 'gumbo_parse')
   end
 end
 
+# We use some Gumbo Internals, and not all distros ship the internal headers.
+header_typedefs = {
+  'error.h' => 'GumboErrorType',
+  'insertion_mode.h' => 'GumboInsertionMode',
+  'parser.h' => 'GumboParser',
+  'string_buffer.h' => 'GumboStringBuffer',
+  'token_type.h' => 'GumboTokenType',
+}
+
+header_typedefs.each_pair do |header, type|
+  unless find_type(type, header)
+    require 'fileutils'
+    FileUtils.cp Dir["#{rakehome}/gumbo-parser/src/#{header}"],
+      "#{rakehome}/ext/nokogumboc"
+  end
+end
+
 create_makefile('nokogumboc')


### PR DESCRIPTION
If a system copy of gumbo is present, we still need to import some
internal headers, as we use internal gumbo types that are not in
gumbo.h. Check if the minimal set of types is available for each header
and copy if needed.

Fixes: https://github.com/rubys/nokogumbo/issues/58
Signed-off-by: Robin H. Johnson <robbat2@gentoo.org>