### PR TITLE
Add :max_parse_errors argument to .parse, .get and .fragment with 0 as default value

### DIFF
--- a/ext/nokogumboc/nokogumbo.c
+++ b/ext/nokogumboc/nokogumbo.c
@@ -218,7 +218,7 @@ static VALUE parse(VALUE self, VALUE string, VALUE max_parse_errors) {
   VALUE rdoc = Nokogiri_wrap_xml_document(Document, doc);
 
   // Add parse errors to rdoc.
-  if (output->errors.length && max_errors > 0) {
+  if (max_errors > 0 && output->errors.length) {
     GumboVector *errors = &output->errors;
     GumboParser parser = { ._options = options };
     GumboStringBuffer msg;

--- a/lib/nokogumbo.rb
+++ b/lib/nokogumbo.rb
@@ -4,14 +4,14 @@ require 'nokogumboc'
 module Nokogiri
   # Parse an HTML document.  +string+ contains the document.  +string+
   # may also be an IO-like object.  Returns a +Nokogiri::HTML::Document+.
-  def self.HTML5(string)
-    Nokogiri::HTML5.parse(string)
+  def self.HTML5(*args)
+    Nokogiri::HTML5.parse(*args)
   end
 
   module HTML5
     # Parse an HTML document.  +string+ contains the document.  +string+
     # may also be an IO-like object.  Returns a +Nokogiri::HTML::Document+.
-    def self.parse(string)
+    def self.parse(string, options={})
       if string.respond_to? :read
         string = string.read
       end
@@ -21,7 +21,7 @@ module Nokogiri
         string = reencode(string)
       end
 
-      Nokogumbo.parse(string.to_s)
+      Nokogumbo.parse(string.to_s, options[:max_parse_errors] || 100)
     end
 
     # Fetch and parse a HTML document from the web, following redirects,
@@ -67,7 +67,7 @@ module Nokogiri
 
       case response
       when Net::HTTPSuccess
-        doc = parse(reencode(response.body, response['content-type']))
+        doc = parse(reencode(response.body, response['content-type']), options)
         doc.instance_variable_set('@response', response)
         doc.class.send(:attr_reader, :response)
         doc
@@ -83,8 +83,8 @@ module Nokogiri
     # while fragment is on the Gumbo TODO list, simulate it by doing
     # a full document parse and ignoring the parent <html>, <head>, and <body>
     # tags, and collecting up the children of each.
-    def self.fragment(string)
-      doc = parse(string)
+    def self.fragment(*args)
+      doc = parse(*args)
       fragment = Nokogiri::HTML::DocumentFragment.new(doc)
 
       if doc.children.length != 1 or doc.children.first.name != 'html'

--- a/lib/nokogumbo.rb
+++ b/lib/nokogumbo.rb
@@ -21,7 +21,7 @@ module Nokogiri
         string = reencode(string)
       end
 
-      Nokogumbo.parse(string.to_s, options[:max_parse_errors] || 100)
+      Nokogumbo.parse(string.to_s, options[:max_parse_errors] || 0)
     end
 
     # Fetch and parse a HTML document from the web, following redirects,

--- a/test-nokogumbo.rb
+++ b/test-nokogumbo.rb
@@ -126,9 +126,9 @@ class TestNokogumbo < Minitest::Test
   end
 
   def test_parse_errors
-    doc = Nokogiri::HTML5("<!DOCTYPE html><html><!-- -- --></a>")
+    doc = Nokogiri::HTML5("<!DOCTYPE html><html><!-- -- --></a>", max_parse_errors: 10)
     assert_equal doc.errors.length, 2
-    doc = Nokogiri::HTML5("<!DOCTYPE html><html>")
+    doc = Nokogiri::HTML5("<!DOCTYPE html><html>", max_parse_errors: 10)
     assert_empty doc.errors
   end
 
@@ -141,13 +141,13 @@ class TestNokogumbo < Minitest::Test
   end
 
   def test_default_max_parse_errors
-    # This document contains 200 parse errors, but default limit is 100.
+    # This document contains 200 parse errors, but default limit is 0.
     doc = Nokogiri::HTML5("<!DOCTYPE html><html>" + "</p>" * 200)
-    assert_equal 100, doc.errors.length
+    assert_equal 0, doc.errors.length
   end
 
   def test_parse_fragment_errors
-    doc = Nokogiri::HTML5.fragment("<\r\n")
+    doc = Nokogiri::HTML5.fragment("<\r\n", max_parse_errors: 10)
     refute_empty doc.errors
   end
 
@@ -158,9 +158,9 @@ class TestNokogumbo < Minitest::Test
   end
 
   def test_fragment_default_max_parse_errors
-    # This fragment contains 201 parse errors, but default limit is 100.
+    # This fragment contains 201 parse errors, but default limit is 0.
     doc = Nokogiri::HTML5.fragment("</p>" * 200)
-    assert_equal 100, doc.errors.length
+    assert_equal 0, doc.errors.length
   end
 
 private

--- a/test-nokogumbo.rb
+++ b/test-nokogumbo.rb
@@ -78,7 +78,7 @@ class TestNokogumbo < Minitest::Test
   end
 
   def test_html5_doctype
-    doc = Nokogumbo.parse("<!DOCTYPE html><html></html>")
+    doc = Nokogiri::HTML5.parse("<!DOCTYPE html><html></html>")
     assert_match /<!DOCTYPE html>/, doc.to_html
   end
 
@@ -132,9 +132,35 @@ class TestNokogumbo < Minitest::Test
     assert_empty doc.errors
   end
 
+  def test_max_parse_errors
+    # This document contains 2 parse errors, but we force limit to 1.
+    doc = Nokogiri::HTML5("<!DOCTYPE html><html><!-- -- --></a>", max_parse_errors: 1)
+    assert_equal 1, doc.errors.length
+    doc = Nokogiri::HTML5("<!DOCTYPE html><html>", max_parse_errors: 1)
+    assert_empty doc.errors
+  end
+
+  def test_default_max_parse_errors
+    # This document contains 200 parse errors, but default limit is 100.
+    doc = Nokogiri::HTML5("<!DOCTYPE html><html>" + "</p>" * 200)
+    assert_equal 100, doc.errors.length
+  end
+
   def test_parse_fragment_errors
     doc = Nokogiri::HTML5.fragment("<\r\n")
     refute_empty doc.errors
+  end
+
+  def test_fragment_max_parse_errors
+    # This fragment contains 3 parse errors, but we force limit to 1.
+    doc = Nokogiri::HTML5.fragment("<!-- -- --></a>", max_parse_errors: 1)
+    assert_equal 1, doc.errors.length
+  end
+
+  def test_fragment_default_max_parse_errors
+    # This fragment contains 201 parse errors, but default limit is 100.
+    doc = Nokogiri::HTML5.fragment("</p>" * 200)
+    assert_equal 100, doc.errors.length
   end
 
 private


### PR DESCRIPTION
Nokogumbo version 1.4.10 introduced [tracking of Gumbo parse errors](https://github.com/rubys/nokogumbo/pull/46) into an `@errors` array on the document. Since upgrading to this version, we started seeing our servers use crazy amounts of memory, swap, and almost instantly crash on some occasions.

Background: we run an [email client](https://missiveapp.com/). Needless to say, we get our fair share of malformed HTML. The specific case that led me to investigate this memory issue was a newsletter that looked legit but ended with the string `"</body></html></table></div>"` repeated 20,000+ times, with no newline. This means 60,000+ parse errors pushed into `@errors` which, probably due to each error containing a string of the full HTML line where it happened, caused insane memory usage.

The only solution for us was to lock Nokogumbo to 1.4.9 in our Gemfile, because this part of code being a C extension, we cannot monkey-patch some Ruby to remove the `@errors` functionality.

If you ask me, I’d say parse error tracking should have been an opt-in feature in the first place. I believe a tiny fraction of Nokogumbo users need it, and for everyone else it’s just useless overhead added to the `parse` method. Yet, version 1.4.10 has been out for over a year and starting to require an explicit argument to get `@errors` tracking would break backward compatibility. Thus, I went with an optional `:max_parse_errors` argument, allowing us to pass `0` to disable the feature. I’ve put a default limit of `100` because I think avoiding crashes like explained above for all Nokogumbo users by default is a significant improvement. Something I haven’t done is accepting `max_parse_errors: nil` as a way to restore the previous limitless behavior. I wasn’t sure whether this was relevant.

Despite the backward incompatiblity it would introduce, it’s worth considering that @jeremy’s [pull request on html-proofer](https://github.com/gjtorikian/html-proofer/pull/362) (which apparently [was the main motivation](https://github.com/rubys/nokogumbo/pull/46#issuecomment-257436257) for releasing the feature in Nokogumbo) is still open, and the Nokogumbo documentation doesn’t mention the error tracking functionality anywhere. So if you guys agree that breaking backward compatibility in this case would be negligible, I think making the feature effectively opt-in would be the best scenario. It would allow regular usage of Nokogumbo with 0 performance impact for users not needing the feature. The only change required to my code would be [replacing `100` with `0`](https://github.com/missive/nokogumbo/blob/52d21d254913c27673722bc6a23531e59bff558c/lib/nokogumbo.rb#L24).

Happy to hear your thoughts.