### PR TITLE
Change the layout to be closer to the standard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 Gemfile.lock
-ext/nokogumboc/*
-!ext/nokogumboc/extconf.rb
-!ext/nokogumboc/nokogumbo.c
-lib
-pkg
-tmp
+ext/nokogumbo/*
+!ext/nokogumbo/extconf.rb
+!ext/nokogumbo/nokogumbo.c
+/lib/nokogumbo/nokogumbo.bundle
+/lib/nokogumbo/nokogumbo.so
+/lib/nokogumbo/nokogumbo.dll
+/pkg
+/tmp

--- a/Gemfile
+++ b/Gemfile
@@ -9,5 +9,6 @@ end
 group :development, :test do
   gem 'minitest'
   gem 'rake'
+  gem 'rake-compiler'
 end
 

--- a/ext/nokogumbo/extconf.rb
+++ b/ext/nokogumbo/extconf.rb
@@ -37,5 +37,5 @@ unless File.exist?(File.join(ext_dir, "gumbo.h"))
   $srcs = $objs = nil
 end
 
-create_makefile('nokogumboc')
+create_makefile('nokogumbo/nokogumbo')
 # vim: set sw=2 sts=2 ts=8 et:

--- a/ext/nokogumbo/nokogumbo.c
+++ b/ext/nokogumbo/nokogumbo.c
@@ -255,7 +255,7 @@ static VALUE parse(VALUE self, VALUE string, VALUE max_parse_errors) {
 }
 
 // Initialize the Nokogumbo class and fetch constants we will use later
-void Init_nokogumboc() {
+void Init_nokogumbo() {
   rb_funcall(rb_mKernel, rb_intern("gem"), 1, rb_str_new2("nokogiri"));
   rb_require("nokogiri");
 
@@ -282,7 +282,7 @@ void Init_nokogumboc() {
   create_internal_subset = rb_intern("create_internal_subset");
 #endif
 
-  // define Nokogumbo class with a singleton parse method
-  VALUE Gumbo = rb_define_class("Nokogumbo", rb_cObject);
+  // define Nokogumbo module with a parse method
+  VALUE Gumbo = rb_define_module("Nokogumbo");
   rb_define_singleton_method(Gumbo, "parse", parse, 2);
 }

--- a/lib/nokogumbo.rb
+++ b/lib/nokogumbo.rb
@@ -1,5 +1,6 @@
 require 'nokogiri'
-require 'nokogumboc'
+require 'nokogumbo/nokogumbo'
+require 'nokogumbo/version'
 
 module Nokogiri
   # Parse an HTML document.  +string+ contains the document.  +string+

--- a/lib/nokogumbo/version.rb
+++ b/lib/nokogumbo/version.rb
@@ -1,0 +1,3 @@
+module Nokogumbo
+  VERSION = "2.0.0"
+end

--- a/test/nokogumbo_test.rb
+++ b/test/nokogumbo_test.rb
@@ -1,8 +1,3 @@
-$:.unshift('lib')
-$:.unshift('ext/nokogumboc')
-
-gem 'minitest'
-
 require 'nokogumbo'
 require 'minitest/autorun'
 
@@ -79,7 +74,7 @@ class TestNokogumbo < Minitest::Test
 
   def test_html5_doctype
     doc = Nokogiri::HTML5.parse("<!DOCTYPE html><html></html>")
-    assert_match /<!DOCTYPE html>/, doc.to_html
+    assert_match(/<!DOCTYPE html>/, doc.to_html)
   end
 
   def test_fragment_head


### PR DESCRIPTION
This PR depends on https://github.com/rubys/nokogumbo/pull/70 but I'm not sure how to base it off of another PR. The only commit this PR has that the other doesn't (at the time of submitting this) is https://github.com/rubys/nokogumbo/commit/b3b071ac423a7e3e3b02e1d53c734deaa7989e38

Note that this changes the version number to 2.0.0. I'm not sure when changing the version number normally happens (i.e., just before making a release or merely some point after the previous release). Assuming we want to go this route, I'd like to fix a few other bugs before pushing out a new gem.

    Change the layout to be closer to the standard

    The [Gems With
    Extensions](https://guides.rubygems.org/gems-with-extensions/) guide has
    concrete layout and naming suggestions for gems with extensions. This
    commit moves things around to fit those suggestions as well as a little
    renaming. Specifically,

    - Rather than `nokogumboc`, the extension is now named `nokogumbo` and
      it is installed as `lib/nokogumbo/nokogumbo.bundle` (or .so on Linux).
    - The `rake-compiler` gem is now used to compile the extension following
      the standard conventions. This simplifies the `Rakefile` a bit.

    Apart from that, standard gem layouts have a `version.rb` file and tests
    live in a `test` directory. This makes the following changes as well.

    - Create a `lib/nokogumbo/version.rb` that contains the version number.
      (I assume we'll want a version bumb for this, so I went with 2.0.0.)
    - The `Rakefile` loads the version from this file.
    - `Nokogumbo` is changed from a class with a singleton method to a
      module with a single method. This seems more appropriate and is also
      necessary to have `Nokogumbo::VERSION` from `version.rb` work.
    - The test has been moved into a `test` directory following the example
      gem you get from running `bundle gem example`. In the future, the
      tests could be split into multiple files based on functionality, if
      desired.
    - The `Rakefile` now uses the standard `Rake::TestTask`