### PR TITLE
Set the encoding to UTF-8 for old versions of Ruby

### DIFF
--- a/test/nokogumbo_test.rb
+++ b/test/nokogumbo_test.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require 'nokogumbo'
 require 'minitest/autorun'
 


### PR DESCRIPTION
Ruby 1.9 defaults to ASCII but the test contains UTF-8.