### PR TITLE
Reorganize tests and add test for issue #68

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -16,7 +16,7 @@ end
 
 Rake::TestTask.new(:test) do |t|
   t.libs << 'test'
-  t.test_files = FileList['test/**/*_test.rb']
+  t.test_files = FileList['test/**/test_*.rb']
 end
 
 task :test => :compile

--- a/test/test_encoding.rb
+++ b/test/test_encoding.rb
@@ -33,7 +33,7 @@ class TestNokogumbo < Minitest::Test
 
   # https://github.com/rubys/nokogumbo/issues/68
   def test_charset_sniff_to_html
-    html = <<~HTML
+    html = <<-EOF.gsub(/^      /, '')
       <!DOCTYPE html>
       <html>
         <head>
@@ -43,7 +43,7 @@ class TestNokogumbo < Minitest::Test
           Hello!
         </body>
       </html>
-    HTML
+    EOF
     doc = Nokogiri::HTML5(html, max_parse_errors: 10)
     assert_equal 0, doc.errors.length
     refute_equal '', doc.to_html

--- a/test/test_encoding.rb
+++ b/test/test_encoding.rb
@@ -30,4 +30,22 @@ class TestNokogumbo < Minitest::Test
       assert_equal '<span>Señor</span>', doc.at('span').to_xml
     end
   end
+
+  # https://github.com/rubys/nokogumbo/issues/68
+  def test_charset_sniff_to_html
+    html = <<~HTML
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <meta http-equiv="Content-Type" content="text/html; charset=utf-8; width=device-width">
+        </head>
+        <body>
+          Hello!
+        </body>
+      </html>
+    HTML
+    doc = Nokogiri::HTML5(html, max_parse_errors: 10)
+    assert_equal 0, doc.errors.length
+    refute_equal '', doc.to_html
+  end
 end

--- a/test/test_encoding.rb
+++ b/test/test_encoding.rb
@@ -1,0 +1,33 @@
+# encoding: utf-8
+require 'nokogumbo'
+require 'minitest/autorun'
+
+class TestNokogumbo < Minitest::Test
+  if ''.respond_to? 'encoding'
+    def test_macroman_encoding
+      mac="<span>\xCA</span>".force_encoding('macroman')
+      doc = Nokogiri::HTML5(mac)
+      assert_equal "<span> </span>", doc.at("span").to_xml
+    end
+
+    def test_iso8859_encoding
+      iso8859="<span>Se\xF1or</span>".force_encoding(Encoding::ASCII_8BIT)
+      doc = Nokogiri::HTML5(iso8859)
+      assert_equal '<span>Señor</span>', doc.at('span').to_xml
+    end
+
+    def test_charset_encoding
+      utf8="<meta charset='utf-8'><span>Se\xC3\xB1or</span>".
+        force_encoding(Encoding::ASCII_8BIT)
+      doc = Nokogiri::HTML5(utf8)
+      assert_equal '<span>Señor</span>', doc.at('span').to_xml
+    end
+
+    def test_bogus_encoding
+      bogus="<meta charset='bogus'><span>Se\xF1or</span>".
+        force_encoding(Encoding::ASCII_8BIT)
+      doc = Nokogiri::HTML5(bogus)
+      assert_equal '<span>Señor</span>', doc.at('span').to_xml
+    end
+  end
+end

--- a/test/test_nokogumbo.rb
+++ b/test/test_nokogumbo.rb
@@ -45,34 +45,6 @@ class TestNokogumbo < Minitest::Test
     assert_equal 1, doc.search('body').count
   end
 
-  if ''.respond_to? 'encoding'
-    def test_macroman_encoding
-      mac="<span>\xCA</span>".force_encoding('macroman')
-      doc = Nokogiri::HTML5(mac)
-      assert_equal "<span> </span>", doc.at("span").to_xml
-    end
-
-    def test_iso8859_encoding
-      iso8859="<span>Se\xF1or</span>".force_encoding(Encoding::ASCII_8BIT)
-      doc = Nokogiri::HTML5(iso8859)
-      assert_equal '<span>Señor</span>', doc.at('span').to_xml
-    end
-
-    def test_charset_encoding
-      utf8="<meta charset='utf-8'><span>Se\xC3\xB1or</span>".
-        force_encoding(Encoding::ASCII_8BIT)
-      doc = Nokogiri::HTML5(utf8)
-      assert_equal '<span>Señor</span>', doc.at('span').to_xml
-    end
-
-    def test_bogus_encoding
-      bogus="<meta charset='bogus'><span>Se\xF1or</span>".
-        force_encoding(Encoding::ASCII_8BIT)
-      doc = Nokogiri::HTML5(bogus)
-      assert_equal '<span>Señor</span>', doc.at('span').to_xml
-    end
-  end
-
   def test_html5_doctype
     doc = Nokogiri::HTML5.parse("<!DOCTYPE html><html></html>")
     assert_match(/<!DOCTYPE html>/, doc.to_html)


### PR DESCRIPTION
This changes the test pattern from `*_test.rb` to `test_*.rb`, splits out the encoding tests, and adds one for #68.