### PR TITLE
Fix missing DOCTYPE errors with fragments

### DIFF
--- a/test/test_nokogumbo.rb
+++ b/test/test_nokogumbo.rb
@@ -50,6 +50,11 @@ class TestNokogumbo < Minitest::Test
     assert_match(/<!DOCTYPE html>/, doc.to_html)
   end
 
+  def test_fragment_no_errors
+    doc = Nokogiri::HTML5.fragment("no missing DOCTYPE errors", max_parse_errors: 10)
+    assert_equal 0, doc.errors.length
+  end
+
   def test_fragment_head
     doc = Nokogiri::HTML5.fragment(buffer[/<head>(.*?)<\/head>/m, 1])
     assert_equal "hello world", doc.xpath('title').text


### PR DESCRIPTION
Follow the procedure that Nokogiri uses to parse fragments. Essentially,
this involves prepending `<!DOCTYPE><html><body>` and parsing as a full
document. After doing this, all of the children of the `body` are
reparented to a new `HTML::DocumentFragment`.

This fixes the issue that `HTML5.fragment` always gives an error due to
a missing DOCTYPE.