### PR TITLE
Improve the error API slightly by adding an explicit length.

### DIFF
--- a/ext/nokogumbo/nokogumbo.c
+++ b/ext/nokogumbo/nokogumbo.c
@@ -229,7 +229,7 @@ static VALUE parse(VALUE self, VALUE string, VALUE max_parse_errors) {
     for (int i=0; i < errors->length; i++) {
       GumboError *err = errors->data[i];
       gumbo_string_buffer_clear(&parser, &msg);
-      gumbo_caret_diagnostic_to_string(&parser, err, input, &msg);
+      gumbo_caret_diagnostic_to_string(&parser, err, input, input_len, &msg);
       VALUE err_str = rb_str_new(msg.data, msg.length);
       VALUE syntax_error = rb_class_new_instance(1, &err_str, XMLSyntaxError);
       rb_iv_set(syntax_error, "@domain", INT2NUM(1)); // XML_FROM_PARSER

--- a/gumbo-parser/src/error.c
+++ b/gumbo-parser/src/error.c
@@ -132,24 +132,25 @@ static void handle_parser_error(GumboParser* parser,
 // Finds the preceding newline in an original source buffer from a given byte
 // location.  Returns a character pointer to the character after that, or a
 // pointer to the beginning of the string if this is the first line.
-static const char* find_last_newline(
-    const char* original_text, const char* error_location) {
-  assert(error_location >= original_text);
+static const char* find_prev_newline(
+    const char* source_text, const char* error_location) {
+  assert(error_location >= source_text);
   const char* c = error_location;
-  if (*c == '\n' && c != original_text)
+  if (*c == '\n' && c != source_text)
     --c;
-  for (; c != original_text && *c != '\n'; --c)
+  for (; c != source_text && *c != '\n'; --c)
     ;
-  return c == original_text ? c : c + 1;
+  return c == source_text ? c : c + 1;
 }
 
 // Finds the next newline in the original source buffer from a given byte
 // location.  Returns a character pointer to that newline, or a pointer to the
 // terminating null byte if this is the last line.
 static const char* find_next_newline(
-    const char* original_text, const char* error_location) {
+    const char* source_text_end, const char* error_location) {
+  assert(error_location <= source_text_end);
   const char* c = error_location;
-  for (; *c && *c != '\n'; ++c)
+  for (; c != source_text_end && *c != '\n'; ++c)
     ;
   return c;
 }
@@ -235,11 +236,11 @@ void gumbo_error_to_string(
 
 void gumbo_caret_diagnostic_to_string(GumboParser* parser,
     const GumboError* error, const char* source_text,
-    GumboStringBuffer* output) {
+    size_t length, GumboStringBuffer* output) {
   gumbo_error_to_string(parser, error, output);
 
-  const char* line_start = find_last_newline(source_text, error->original_text);
-  const char* line_end = find_next_newline(source_text, error->original_text);
+  const char* line_start = find_prev_newline(source_text, error->original_text);
+  const char* line_end = find_next_newline(source_text+length, error->original_text);
   GumboStringPiece original_line;
   original_line.data = line_start;
   original_line.length = line_end - line_start;
@@ -257,10 +258,11 @@ void gumbo_caret_diagnostic_to_string(GumboParser* parser,
 }
 
 void gumbo_print_caret_diagnostic(
-    GumboParser* parser, const GumboError* error, const char* source_text) {
+    GumboParser* parser, const GumboError* error, const char* source_text,
+    size_t length) {
   GumboStringBuffer text;
   gumbo_string_buffer_init(parser, &text);
-  gumbo_caret_diagnostic_to_string(parser, error, source_text, &text);
+  gumbo_caret_diagnostic_to_string(parser, error, source_text, length, &text);
   printf("%.*s", (int) text.length, text.data);
   gumbo_string_buffer_destroy(parser, &text);
 }

--- a/gumbo-parser/src/error.h
+++ b/gumbo-parser/src/error.h
@@ -210,13 +210,13 @@ void gumbo_error_to_string(struct GumboInternalParser* parser,
 // allocated with the allocator specified in the GumboParser config and hence
 // should be freed by gumbo_parser_deallocate().)
 void gumbo_caret_diagnostic_to_string(struct GumboInternalParser* parser,
-    const GumboError* error, const char* source_text,
+    const GumboError* error, const char* source_text, size_t length,
     GumboStringBuffer* output);
 
 // Like gumbo_caret_diagnostic_to_string, but prints the text to stdout instead
 // of writing to a string.
 void gumbo_print_caret_diagnostic(struct GumboInternalParser* parser,
-    const GumboError* error, const char* source_text);
+    const GumboError* error, const char* source_text, size_t length);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
With NULL bytes, the original error API won't print out the whole line. Instead, it stops at the 0. This fixes that.