### PR TITLE
Add flags to control how nokogumbo is built

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,11 @@ rvm: # http://rubies.travis-ci.org/
   - 2.3
   - 2.4.0 # https://github.com/travis-ci/travis-ci/issues/7848
   - 2.5
+env:
+  - WITH_LIBXML=true
+  - WITH_LIBXML=true NOKOGIRI_USE_SYSTEM_LIBRARIES=true
+  - WITH_LIBXML=false
 matrix:
-  exclude:
-    - os: osx
-      rvm: 2.0
-    - os: osx
-      env: WITH_LIBXML=false
   include:
     - name: test gumbo
       os: osx
@@ -36,14 +35,14 @@ matrix:
       script:
         - make -C gumbo-parser
 
-env:
-  - WITH_LIBXML=true
-  - WITH_LIBXML=false
 before_script:
-  - if [ "$WITH_LIBXML" = "false" ]; then sudo apt-get remove libxml2-dev; fi
+  - |
+    if [ "$WITH_LIBXML" == "true" ]; then
+      MAKE='make V=1' bundle exec rake compile -- --with-libxml2
+    else
+      MAKE='make V=1' bundle exec rake compile -- --without-libxml2
+    fi
   - cd test && git clone --depth 1 --branch master --single-branch https://github.com/html5lib/html5lib-tests.git
 script:
-  - MAKE='make V=1' bundle exec rake compile
   - bundle exec rake
-sudo: required
 cache: bundler

--- a/Gemfile
+++ b/Gemfile
@@ -10,5 +10,6 @@ group :development, :test do
   gem 'minitest'
   gem 'rake'
   gem 'rake-compiler'
+  gem 'pkg-config'
 end
 

--- a/ext/nokogumbo/extconf.rb
+++ b/ext/nokogumbo/extconf.rb
@@ -1,27 +1,103 @@
 require 'mkmf'
+require 'nokogiri'
 $CFLAGS += " -std=c99"
 
 $warnflags = CONFIG['warnflags'] = '-Wall'
 
-if have_library('xml2', 'xmlNewDoc') 
-  # libxml2 libraries from http://www.xmlsoft.org/
-  pkg_config('libxml-2.0')
+NG_SPEC = Gem::Specification.find_by_name('nokogiri', "= #{Nokogiri::VERSION}")
 
-  # nokogiri configuration from gem install
-  nokogiri_lib = Gem.find_files('nokogiri').
-    select { |name| name.match(%r{gems/nokogiri-([\d.]+)/lib/nokogiri}) }.
-    sort_by {|name| name[/nokogiri-([\d.]+)/,1].split('.').map(&:to_i)}.last
-  if nokogiri_lib
-    nokogiri_ext = nokogiri_lib.sub(%r(lib/nokogiri(.rb)?$), 'ext/nokogiri')
+def download_headers
+  begin
+    require 'yaml'
 
-    # if that doesn't work, try workarounds found in Nokogiri's extconf
-    unless find_header('nokogiri.h', nokogiri_ext)
-      require "#{nokogiri_ext}/extconf.rb"
+    dependencies = YAML.load_file(File.join(NG_SPEC.gem_dir, 'dependencies.yml'))
+    version = dependencies['libxml2']['version']
+    host = RbConfig::CONFIG["host_alias"].empty? ? RbConfig::CONFIG["host"] : RbConfig::CONFIG["host_alias"]
+    path = File.join('ports', host, 'libxml2', version, 'include/libxml2')
+    return path if File.directory?(path)
+
+    # Make sure we're using the same version Nokogiri uses
+    dep_index = NG_SPEC.dependencies.index { |dep| dep.name == 'mini_portile2' and dep.type == :runtime }
+    return nil if dep_index.nil?
+    requirement = NG_SPEC.dependencies[dep_index].requirement.to_s
+
+    require 'rubygems'
+    gem 'mini_portile2', requirement
+    require 'mini_portile2'
+    p = MiniPortile::new('libxml2', version).tap do |r|
+      r.host = RbConfig::CONFIG["host_alias"].empty? ? RbConfig::CONFIG["host"] : RbConfig::CONFIG["host_alias"]
+      r.files = [{
+        url: "http://xmlsoft.org/sources/libxml2-#{r.version}.tar.gz",
+        sha256: dependencies['libxml2']['sha256']
+      }]
+      r.configure_options += [
+        "--without-python",
+        "--without-readline",
+        "--with-c14n",
+        "--with-debug",
+        "--with-threads"
+      ]
+    end
+    p.download unless p.downloaded?
+    p.extract
+    p.configure unless p.configured?
+    system('make', '-C', "tmp/#{p.host}/ports/libxml2/#{version}/libxml2-#{version}/include/libxml", 'install-xmlincHEADERS')
+    path
+  rescue
+    puts 'failed to download/install headers'
+    nil
+  end
+end
+
+required = arg_config('--with-libxml2')
+prohibited = arg_config('--without-libxml2')
+if required and prohibited
+  abort "cannot use both --with-libxml2 and --without-libxml2"
+end
+
+have_libxml2 = false
+have_ng = false
+
+if !prohibited
+  if Nokogiri::VERSION_INFO.include?('libxml') and
+     Nokogiri::VERSION_INFO['libxml']['source'] == 'packaged'
+    # Nokogiri has libxml2 built in. Find the headers.
+    libxml2_path = File.join(Nokogiri::VERSION_INFO['libxml']['libxml2_path'],
+                             'include/libxml2')
+    if find_header('libxml/tree.h', libxml2_path)
+      have_libxml2 = true
+    else
+      # Unfortunately, some versions of Nokogiri delete these files.
+      # https://github.com/sparklemotion/nokogiri/pull/1788
+      # Try to download them
+      libxml2_path = download_headers
+      unless libxml2_path.nil?
+        have_libxml2 = find_header('libxml/tree.h', libxml2_path)
+      end
+    end
+  else
+    # Nokogiri is compiled with system headers.
+    # Hack to work around broken mkmf on macOS
+    # (https://bugs.ruby-lang.org/issues/14992 fixed now)
+    if RbConfig::MAKEFILE_CONFIG['LIBPATHENV'] == 'DYLD_LIBRARY_PATH'
+      RbConfig::MAKEFILE_CONFIG['LIBPATHENV'] = 'DYLD_FALLBACK_LIBRARY_PATH'
     end
 
-    # if found, enable direct calls to Nokogiri (and libxml2)
-    $CFLAGS += ' -DNGLIB' if find_header('nokogiri.h', nokogiri_ext)
+    pkg_config('libxml-2.0')
+    have_libxml2 = have_library('xml2', 'xmlNewDoc')
   end
+  if required and !have_libxml2
+    abort "libxml2 required but could not be located"
+  end
+
+  if have_libxml2
+    # Find nokogiri.h
+    have_ng = find_header('nokogiri.h', File.join(NG_SPEC.gem_dir, 'ext/nokogiri'))
+  end
+end
+
+if have_libxml2 and have_ng
+  $CFLAGS += " -DNGLIB=1"
 end
 
 # Symlink gumbo-parser source files.


### PR DESCRIPTION
There are three configurations
1. --with-libxml2 forces nokogumbo to be built with the libxml2 headers;
2. --without-libxml2 forces nokogumbo to be built without the libxml2
   headers; and
3. (default) try hard to build with headers, but allow that process to
   fail and build without the headers.

By default, Nokogiri packages libxml2 as part of the binary. Current
versions of Nokogiri delete the libxml2 headers as part of the install.
This first checks to see if they haven't been deleted and if not, it
uses them. If they have been deleted, it downloads, configures, and then
installs the headers (in the `ext/nokogiri/.../libxml2` directory) of
the corresponding version.

However, if Nokogiri hasn't packaged libxml2, then it used the system
libraries. In this case, use `pkg-config` to locates the library/headers.

Hopefully, Nokogiri will start including the headers again at which
point the `download_headers` function can be removed.