### PR TITLE
Don't replace "invalid" characters with U+FFFD

### DIFF
--- a/gumbo-parser/src/utf8.c
+++ b/gumbo-parser/src/utf8.c
@@ -148,8 +148,10 @@ static void read_char(Utf8Iterator* iter) {
         code_point = '\n';
       }
       if (utf8_is_invalid_code_point(code_point)) {
+	// Invalid code points are errors, but they are not replaced by
+	// U+FFFD.
+	// https://html.spec.whatwg.org/multipage/parsing.html#preprocessing-the-input-stream
         add_error(iter, GUMBO_ERR_UTF8_INVALID);
-        code_point = kUtf8ReplacementChar;
       }
       iter->_current = code_point;
       return;

--- a/gumbo-parser/test/utf8.cc
+++ b/gumbo-parser/test/utf8.cc
@@ -336,11 +336,11 @@ TEST_F(Utf8Test, 0xFFIsError) {
   EXPECT_EQ('x', utf8iterator_current(&input_));
 }
 
-TEST_F(Utf8Test, InvalidControlCharIsError) {
+TEST_F(Utf8Test, InvalidControlCharIsNotReplaced) {
   ResetText("\x1Bx");
 
   EXPECT_EQ(1, GetNumErrors());
-  EXPECT_EQ(0xFFFD, utf8iterator_current(&input_));
+  EXPECT_EQ(0x001b, utf8iterator_current(&input_));
 
   utf8iterator_next(&input_);
   EXPECT_EQ('x', utf8iterator_current(&input_));


### PR DESCRIPTION
https://html.spec.whatwg.org/multipage/parsing.html#preprocessing-the-input-stream
is clear that surrogates, noncharacters, and controls other than ASCII
whitespace and U+0000 are parse errors, but they are not replaced.

The informative descriptions of the corresponding errors

- [surrogate-in-input-stream](https://html.spec.whatwg.org/multipage/parsing.html#parse-error-surrogate-in-input-stream),
- [noncharacter-in-input-stream](https://html.spec.whatwg.org/multipage/parsing.html#parse-error-noncharacter-in-input-stream), and
- [control-character-in-input-stream](https://html.spec.whatwg.org/multipage/parsing.html#parse-error-control-character-in-input-stream)

say, "Such code points are parsed as-is and usually [...] make their way
into the DOM."