### PR TITLE
Test building on Gentoo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,41 +8,36 @@ rvm: # http://rubies.travis-ci.org/
   - 2.1
   - 2.2
   - 2.3
-  - 2.4.0 # https://github.com/travis-ci/travis-ci/issues/7848
+  - 2.4.4 # https://github.com/travis-ci/travis-ci/issues/7848
   - 2.5
 env:
-  - WITH_LIBXML=true
-  - WITH_LIBXML=true NOKOGIRI_USE_SYSTEM_LIBRARIES=true
-  - WITH_LIBXML=false
+  - USE_SYSTEM_LIBRARIES=true
+  - USE_SYSTEM_LIBRARIES=false
 matrix:
   include:
+    - name: test gentoo
+      os: linux
+      rvm: 2.3 # Seems to be what Gentoo is using, not that it should matter
+      sudo: required
+      serices:
+        - docker
+      before_install: docker pull stevecheckoway/gentoo-ruby
+      script: scripts/gentoo-test.sh
     - name: test gumbo
       os: osx
       language: cpp
       install:
         - curl -L https://github.com/google/googletest/archive/release-1.8.0.tar.gz | tar zxf - --strip-components 1 -C gumbo-parser googletest-release-1.8.0/googletest
         - make -C gumbo-parser/googletest/make gtest_main.a
-      before_script: true
-      script:
-        - make -C gumbo-parser
+      script: make -C gumbo-parser
     - name: test gumbo
       os: linux
       language: cpp
       install:
         - curl -L https://github.com/google/googletest/archive/release-1.8.0.tar.gz | tar zxf - --strip-components 1 -C gumbo-parser googletest-release-1.8.0/googletest
         - make -C gumbo-parser/googletest/make gtest_main.a
-      before_script: true
-      script:
-        - make -C gumbo-parser
+      script: make -C gumbo-parser
 
-before_script:
-  - |
-    if [ "$WITH_LIBXML" == "true" ]; then
-      MAKE='make V=1' bundle exec rake compile -- --with-libxml2
-    else
-      MAKE='make V=1' bundle exec rake compile -- --without-libxml2
-    fi
-  - cd test && git clone --depth 1 --branch master --single-branch https://github.com/html5lib/html5lib-tests.git
-script:
-  - bundle exec rake
+install: git clone --depth 1 --branch master --single-branch https://github.com/html5lib/html5lib-tests.git test/html5lib-tests
+script: scripts/ci-test.sh
 cache: bundler

--- a/Gemfile
+++ b/Gemfile
@@ -1,15 +1,16 @@
 source 'https://rubygems.org'
 
-if RUBY_VERSION =~ /^1|^2\.0/
-  gem 'nokogiri', '~> 1.6.8'
-else
-  gem 'nokogiri'
-end
+# Nokogiri depends on pkg-config when built with system libraries but it
+# doesn't declare this dependency. Unfortunately, bundler provides no way to
+# declare additional dependencies and it will install dependencies in
+# alphabetical order so it tries to install Nokogiri before pkg-config and
+# this fails.
+gem 'fix-dep-order', :path => 'scripts'
+gem 'nokogiri', '~> 1.6.8'
 
 group :development, :test do
   gem 'minitest'
   gem 'rake'
   gem 'rake-compiler'
-  gem 'pkg-config'
 end
 

--- a/ext/nokogumbo/extconf.rb
+++ b/ext/nokogumbo/extconf.rb
@@ -1,7 +1,9 @@
+require 'fileutils'
 require 'mkmf'
 require 'nokogiri'
-$CFLAGS += " -std=c99"
 
+$CFLAGS += " -std=c99"
+$LDFLAGS.gsub!('-Wl,--no-undefined', '')
 $warnflags = CONFIG['warnflags'] = '-Wall'
 
 NG_SPEC = Gem::Specification.find_by_name('nokogiri', "= #{Nokogiri::VERSION}")
@@ -103,11 +105,8 @@ end
 # Symlink gumbo-parser source files.
 ext_dir = File.dirname(__FILE__)
 gumbo_src = File.join(ext_dir, 'gumbo_src')
-unless File.symlink?(gumbo_src)
-  require 'fileutils'
-  gumbo_src_dir = File.expand_path('../../gumbo-parser/src', ext_dir)
-  FileUtils.ln_s(gumbo_src_dir, gumbo_src)
-end
+
+FileUtils.ln_s('../../gumbo-parser/src', gumbo_src, force: true)
 
 Dir.chdir(ext_dir) do
   $srcs = Dir['*.c', 'gumbo_src/*.c']

--- a/scripts/ci-test.sh
+++ b/scripts/ci-test.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -e
+set -o pipefail
+set -v
+
+if [ "$USE_SYSTEM_LIBRARIES" = true ]; then
+	export NOKOGIRI_USE_SYSTEM_LIBRARIES=true
+fi
+bundle install --path vendor/bundle
+MAKE='make V=1' bundle exec rake -- --without-libxml2
+bundle exec rake clean
+MAKE='make V=1' bundle exec rake -- --with-libxml2

--- a/scripts/fix-dep-order.gemspec
+++ b/scripts/fix-dep-order.gemspec
@@ -1,0 +1,8 @@
+Gem::Specification.new do |s|
+  s.name = 'fix-dep-order'
+  s.version = '0.1.0'
+  s.author = 'Stephen Checkoway <s@pahtak.org>'
+  s.files = []
+  s.summary = 'Fix Nokogiri not depending on pkg-config'
+  s.add_runtime_dependency 'pkg-config'
+end

--- a/scripts/gentoo-test.sh
+++ b/scripts/gentoo-test.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -e
+set -o pipefail
+set -v
+
+cleanup() {
+	rm -f .dockerignore
+	if [ -n "$image" ]; then
+		docker rmi "$image"
+	fi
+}
+
+cd "$(dirname "$0")/.."
+if [ -e .dockerignore ]; then
+	echo 'Found an existing .dockerignore; aborting' >&2
+	exit 1
+fi
+
+# Cleanup .dockerignore on exit
+trap cleanup EXIT
+
+cat >.dockerignore <<EOF
+.*
+tmp
+vendor
+tags
+EOF
+docker build -t gentoo-build-test -f - . <<EOF
+FROM stevecheckoway/gentoo-ruby
+ADD --chown=user:user . /home/user
+EOF
+image=gentoo-build-test
+if [ -n "$DEBUG_DOCKER" ]; then
+	docker run --rm -it "$image"
+else
+	docker run --rm -a STDOUT -a STDERR "$image" scripts/ci-test.sh
+fi

--- a/test/test_tree-construction.rb
+++ b/test/test_tree-construction.rb
@@ -213,7 +213,7 @@ Dir[File.join(tc_path, '*.dat')].each do |path|
     .map { |s| s.capitalize }
     .join('')
   tests = []
-  File.open(path, "r") do |f|
+  File.open(path, "r", encoding: 'UTF-8') do |f|
     f.each("\n\n#data\n") do |test_data|
       if test_data.start_with?("#data\n")
         test_data = test_data[6..-1]


### PR DESCRIPTION
This involves several fixes:
1. Removing the linker flag that causes the error.
2. Adding scripts to simplify and speed up testing, in particular both
   the `--with-libxml2` and `--without-libxml2` are tested in each
   build.
3. Adding a script to create and run a Docker container based on
   stevecheckoway/gentoo-ruby which is based on the official Gentoo
   image but with ruby, libxml2, and bundler installed.
4. A somewhat unrelated change to fix an issue when Nokogiri is built
   with system libraries. In this case, `pkg-config` needs to be
   available which is easiest to provide via the `pkg-config` gem.
   Unfortunately, bundler installs dependencies in alphabetical order
   and this needs to be installed before Nokogiri. To resolve this,
   `scripts/fix-dep-order.gemspec` (which comes alphabetically before
   `nokogiri`) declares a dependency on `pkg-config` thus building it
   first. This is a ridiculous work-around, but I couldn't find an
   alternative.