### PR TITLE
Add support for HTML5 serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Experimental support for errors (it was supported in 1.5.0 but
   undocumented).
+- Added proper HTML5 serialization.
 
 ### Changed
 - Integrated [Gumbo parser](https://github.com/google/gumbo-parser) into

--- a/lib/nokogumbo/xml/node.rb
+++ b/lib/nokogumbo/xml/node.rb
@@ -9,11 +9,47 @@ module Nokogiri
       # and tries to create an attribute in a namespace. This is especially
       # annoying with attribute names like xml:lang since libxml2 will
       # actually create the xml namespace if it doesn't exist already.
-      def add_child_node_and_reparent_attrs node
+      define_method(:add_child_node_and_reparent_attrs) do |node|
         add_child_node(node)
         node.attribute_nodes.find_all { |a| a.namespace }.each do |attr|
           attr.remove
           node[attr.name] = attr.value
+        end
+      end
+
+      def inner_html(options = {})
+        result = options[:preserve_newline] && HTML5.prepend_newline?(self) ? "\n" : ""
+        result << children.map { |child| child.to_html(options) }.join
+        result
+      end
+
+      def write_to(io, *options)
+        options = options.first.is_a?(Hash) ? options.shift : {}
+        encoding = options[:encoding] || options[0]
+        if Nokogiri.jruby?
+          save_options = options[:save_with] || options[1]
+          indent_times = options[:indent] || 0
+        else
+          save_options = options[:save_with] || options[1] || SaveOptions::FORMAT
+          indent_times = options[:indent] || 2
+        end
+        indent_string = (options[:indent_text] || ' ') * indent_times
+
+        config = SaveOptions.new(save_options.to_i)
+        yield config if block_given?
+
+        config_options = config.options
+        if (config_options & (SaveOptions::AS_XML | SaveOptions::AS_XHTML) != 0) || !document.is_a?(HTML5::Document)
+          # Use Nokogiri's serializing code.
+          native_write_to(io, encoding, indent_string, config_options)
+        else
+          # Serialize including the current node.
+          encoding ||= document.encoding || Encoding::UTF_8
+          internal_ops = {
+            trailing_nl: config_options & SaveOptions::FORMAT != 0,
+            preserve_newline: options[:preserve_newline] || false
+          }
+          HTML5.serialize_node_internal(self, io, encoding, options)
         end
       end
     end

--- a/test/test_encoding.rb
+++ b/test/test_encoding.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require 'nokogumbo'
 require 'minitest/autorun'
 
@@ -47,5 +46,115 @@ class TestNokogumbo < Minitest::Test
     doc = Nokogiri::HTML5(html, max_errors: 10)
     assert_equal 0, doc.errors.length
     refute_equal '', doc.to_html
+  end
+
+  # https://encoding.spec.whatwg.org/#names-and-labels
+  # I chose these by looking at the Wikipedia page for each encoding, picked
+  # one of the languages it was supposed to encode, and then Googled for a
+  # proverb in the language. Apologies if these are ill-chosen or nonsensical.
+  # I'm happy to change them. I'm just pasting them in here so I'm pretty sure
+  # the right-to-left languages are backward. Corrections welcome.
+  ENCODINGS = [
+    ['UTF-8',          "Let's concatentate all of these for UTF-8"], # English
+    ['IBM866',         'А дело бывало -- и коза волка съедала'], # Russian
+    ['ISO-8859-2',     'Co můžeš udělat dnes, neodkládej na zítřek.'], # Czech
+    ['ISO-8859-3',     'Yukarda mavi gök, asağıda yağız yer yaratıldıkta'], # Turkish
+    ['ISO-8859-4',     'Ceļš uz elli ir bruģēts ar labiem nodomiem.'], # Latvian
+    ['ISO-8859-5',     'Каде има сила, нема правдина.'], # Macedonian
+    ['ISO-8859-6',     'أباد الله خضراءهم ابذل لصديقك دمك ومالك'], # Arabic
+    ['ISO-8859-7',     'Η καλύτερη άμυνα είναι η επίθεση.'], # Greek
+    ['ISO-8859-8',     'אין הנחתום מעיד על עיסתו'], # Hebrew
+    ['ISO-8859-8-I',   'אל תסתכל בקנקן, אלא במה שבתוכו'], # Hebrew
+    ['ISO-8859-10',    'Alla känner apan, men apan känner ingen.'], # Swedish
+    ['ISO-8859-13',    'Lašas po lašo ir akmenį pratašo.'], # Lithuanian
+    ['ISO-8859-14',    "ha bhòrd bòrd gun aran ach 's bòrd aran leis fhèin."], # Scottish Gaelic
+    ['ISO-8859-15',    'This is essentially ISO 8859-1 but with € Š š Ž ž Œ œ Ÿ'], # English
+    ['ISO-8859-16',    'Kiedy wszedłeś między wrony, musisz krakać jak i one.'], # Polish
+    ['KOI8-R',         'А дело бывало -- и коза волка съедала'], # Russian
+    ['KOI8-U',         'Яблуко від яблуньки не далеко. Ґ, Є, І, Ї'], # Ukrainian
+    ['macintosh',      'Some good old Mac Roman œ∑´®†¥¨ˆøπåßƒ©'], # XXX: Shifted macroman?
+    ['windows-874',    'กระต่ายหมายจันทร์'], # Thai
+    ['windows-1250',   'Addig nyújtózkodj, amíg a takaród ér.'], # Hungarian
+    ['windows-1251',   'Бързата работа - срам за майстора.'], # Bulgarian
+    ['windows-1252',   'Basically ISO 8859-1 with ‘differences’™ •'], # English
+    ['windows-1253',   'Και οι τοίχοι έχουν αυτιά.'], # Greek
+    ['windows-1254',   'Baban nasılsa oğlu da öyledir.'], # Turkish
+    ['windows-1255',   'אל תקנה חתול בשק; ₪'], # Hebrew
+    ['windows-1256',   'أبطأ من سلحفاة'], # Arabic
+    ['windows-1257',   'Hommikune töö kuld, õhtune muld.'], # Estonian
+    ['windows-1258',   'Ăn theo thuở, ở theo thời.'], # Vietnamese
+    ['x-mac-cyrillic', 'А дело бывало -- и коза волка съедала'], # Russian; XXX: Shifted MacCyrillic?
+    ['GBK',            '不闻不若闻之，闻之不若见之，见之不若知之，知之不若行之；学至于行之而止矣'], # Simplified Chinese
+    ['gb18030',        '不聞不若聞之，聞之不若見之，見之不若知之，知之不若行之；學至於行之而止矣'], # Traditional Chinese
+    ['Big5',           '有其父必有其子'], # Traditional Chinese
+    ['EUC-JP',         '猿も木から落ちる'], # Japanese
+    ['ISO-2022-JP',    '井の中の蛙大海を知らず'], # Japanese
+    ['Shift_JIS',      '鳥なき里の蝙蝠'], # Japanese
+    ['EUC-KR',         '아는 길도 물어가라'], # Korean
+    ['replacement',    '콩 심은데 콩나고, 팥 심은데 팥난다'], # Korean
+    ['UTF-16BE',       'Everything had better be representable!'], # English
+    ['UTF-16LE',       'Same as with UTF-16BE'], # English
+    ['US-ASCII',       'Surprisingly not one of the required encodings'] # English
+  ].freeze
+
+  def encodings_html
+    @encodings_html ||=
+      "<!DOCTYPE html><html><head></head><body>" +
+      ENCODINGS.map { |enc| %(<span id="#{enc[0]}">#{enc[1]}</span>) }.join +
+      '</body></html>'
+  end
+
+  def encodings_doc
+    @encodings_doc ||= Nokogiri::HTML5(encodings_html)
+  end
+
+  def round_trip_through(str, enc)
+    begin
+      encoding = Encoding.find(enc)
+    rescue ArgumentError
+      skip "#{enc} not supported"
+    end
+    begin
+      encoded = str.encode(encoding)
+    rescue Encoding::ConverterNotFoundError
+      skip "Converting UTF-8 to #{str} not supported"
+    end
+    begin
+      decoded = encoded.encode('UTF-8')
+    rescue Encoding::ConverterNotFoundError
+      skip "Converting #{enc} to UTF-8 not supported"
+    end
+    assert_equal str, decoded, "'#{str}' did not round trip through #{enc[0]}"
+    encoded
+  end
+
+  ENCODINGS.each do |enc|
+    define_method("test_parse_encoded_#{enc[0]}".to_sym) do
+      html = "<!DOCTYPE html><span>#{enc[1]}</span>"
+      encoded_html = round_trip_through(html, enc[0])
+      doc = Nokogiri::HTML5(encoded_html, encoding: enc[0])
+      span = doc.at('/html/body/span')
+      refute_nil span
+      assert_equal enc[1], span.content
+    end
+
+    define_method("test_inner_html_encoded_#{enc[0]}".to_sym) do
+      encoded = round_trip_through(enc[1], enc[0])
+      span = encodings_doc.at(%(/html/body/span[@id="#{enc[0]}"]))
+      refute_nil span
+      assert_equal encoded, span.inner_html(encoding: enc[0])
+    end
+
+    define_method("test_roundtrip_through_#{enc[0]}".to_sym) do
+      # https://bugs.ruby-lang.org/issues/15033
+      # Ruby has a bug with the `:fallback` parameter passed to `#encode` when
+      # multiple conversions have to happen. I'm not sure it's worth working
+      # around. It impacts this test though.
+      skip 'https://bugs.ruby-lang.org/issues/15033' if enc[0] == 'ISO-2022-JP'
+      round_trip_through(enc[1], enc[0])
+      encoded = encodings_doc.serialize(encoding: enc[0])
+      doc = Nokogiri::HTML5(encoded, encoding: enc[0])
+      assert_equal encodings_html, doc.serialize
+    end
   end
 end

--- a/test/test_serialize.rb
+++ b/test/test_serialize.rb
@@ -1,0 +1,510 @@
+# encoding: utf-8
+require 'nokogumbo'
+require 'minitest/autorun'
+
+class TestAPI < Minitest::Test
+  # https://github.com/web-platform-tests/wpt/blob/master/html/syntax/serializing-html-fragments/initial-linefeed-pre.html
+  def initial_linefeed_pre
+    @initial_linefeed_pre ||= begin
+      html = <<-EOF.gsub(/^        /, '').freeze
+        <!DOCTYPE html>
+        <div id="outer">
+        <div id="inner">
+        <pre id="pre1">
+        x</pre>
+        <pre id="pre2">
+        
+        x</pre>
+        <textarea id="textarea1">
+        x</textarea>
+        <textarea id="textarea2">
+        
+        x</textarea>
+        <listing id="listing1">
+        x</listing>
+        <listing id="listing2">
+        
+        x</listing>
+        </div>
+        </div>
+        EOF
+      Nokogiri::HTML5(html)
+    end
+    @initial_linefeed_pre
+  end
+
+  def test_initial_linefeed_pre_outer
+    expected = %{\n<div id="inner">\n<pre id="pre1">x</pre>\n<pre id="pre2">\nx</pre>\n<textarea id="textarea1">x</textarea>\n<textarea id="textarea2">\nx</textarea>\n<listing id="listing1">x</listing>\n<listing id="listing2">\nx</listing>\n</div>\n}
+    outer = initial_linefeed_pre.xpath('//div[@id="outer"]')[0]
+    refute_nil outer
+    assert_equal expected, outer.inner_html
+  end
+
+  def test_initial_linefeed_pre_inner
+    expected = %{\n<pre id="pre1">x</pre>\n<pre id="pre2">\nx</pre>\n<textarea id="textarea1">x</textarea>\n<textarea id="textarea2">\nx</textarea>\n<listing id="listing1">x</listing>\n<listing id="listing2">\nx</listing>\n}
+    inner = initial_linefeed_pre.at('//div[@id="inner"]')
+    refute_nil inner
+    assert_equal expected, inner.inner_html
+  end
+
+  %w[pre textarea listing].each do |tag|
+    define_method("test_initial_linefeed_#{tag}1".to_sym) do
+      elem = initial_linefeed_pre.at("//*[@id=\"#{tag}1\"]")
+      refute_nil elem
+      assert_equal 'x', elem.inner_html
+    end
+
+    define_method("test_initial_linefeed_#{tag}2".to_sym) do
+      elem = initial_linefeed_pre.at("//*[@id=\"#{tag}2\"]")
+      refute_nil elem
+      assert_equal "\nx", elem.inner_html
+    end
+  end
+
+  # https://github.com/web-platform-tests/wpt/blob/master/html/syntax/serializing-html-fragments/outerHTML.html
+  ELEMENTS_WITH_END_TAG = [
+    "a",
+    "abbr",
+    "address",
+    "article",
+    "aside",
+    "audio",
+    "b",
+    "bdi",
+    "bdo",
+    "blockquote",
+    "body",
+    "button",
+    "canvas",
+    "caption",
+    "cite",
+    "code",
+    "colgroup",
+    "command",
+    "datalist",
+    "dd",
+    "del",
+    "details",
+    "dfn",
+    "dialog",
+    "div",
+    "dl",
+    "dt",
+    "em",
+    "fieldset",
+    "figcaption",
+    "figure",
+    "footer",
+    "form",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "head",
+    "header",
+    "hgroup",
+    "html",
+    "i",
+    "iframe",
+    "ins",
+    "kbd",
+    "label",
+    "legend",
+    "li",
+    "map",
+    "mark",
+    "menu",
+    "meter",
+    "nav",
+    "noscript",
+    "object",
+    "ol",
+    "optgroup",
+    "option",
+    "output",
+    "p",
+    "pre",
+    "progress",
+    "q",
+    "rp",
+    "rt",
+    "ruby",
+    "s",
+    "samp",
+    "script",
+    "section",
+    "select",
+    "small",
+    "span",
+    "strong",
+    "style",
+    "sub",
+    "summary",
+    "sup",
+    "table",
+    "tbody",
+    "td",
+    "textarea",
+    "tfoot",
+    "th",
+    "thead",
+    "time",
+    "title",
+    "tr",
+    "u",
+    "ul",
+    "var",
+    "video",
+    "data",
+  ].freeze
+
+  ELEMENTS_WITHOUT_END_TAG = [
+    "area",
+    "base",
+    "br",
+    "col",
+    "embed",
+    "hr",
+    "img",
+    "input",
+    "keygen",
+    "link",
+    "meta",
+    "param",
+    "source",
+    "track",
+    "wbr",
+  ]
+
+  ELEMENTS_WITH_END_TAG.each do |tag|
+    define_method("test_outer_html_#{tag}".to_sym) do
+      doc = Nokogiri::HTML5::Document.new
+      child = Nokogiri::XML::Node.new(tag, doc)
+      assert_equal "<#{tag}></#{tag}>", child.serialize(save_with: 0)
+    end
+  end
+
+  ELEMENTS_WITHOUT_END_TAG.each do |tag|
+    define_method("test_outer_html_#{tag}".to_sym) do
+      doc = Nokogiri::HTML5::Document.new
+      child = Nokogiri::XML::Node.new(tag, doc)
+      assert_equal "<#{tag}>", child.serialize(save_with: 0)
+    end
+  end
+
+  # https://github.com/web-platform-tests/wpt/blob/master/html/syntax/serializing-html-fragments/serializing.html
+  def serializing_test_data
+    @serializing_test_data ||= begin
+      html = <<-EOF.gsub(/        /, '')
+        <!DOCTYPE html>
+        <div id="test" style="display:none">
+        <span></span>
+        <span><a></a></span>
+        <span><a b=c></a></span>
+        <span><a b='c'></a></span>
+        <span><a b='&'></a></span>
+        <span><a b='&nbsp;'></a></span>
+        <span><a b='"'></a></span>
+        <span><a b="<"></a></span>
+        <span><a b=">"></a></span>
+        <span><svg xlink:href="a"></svg></span>
+        <span><svg xmlns:svg="test"></svg></span>
+        <span>a</span>
+        <span>&amp;</span>
+        <span>&nbsp;</span>
+        <span>&lt;</span>
+        <span>&gt;</span>
+        <span>&quot;</span>
+        <span><style><&></style></span>
+        <span><script type="test"><&></script></span>
+        <script type="test"><&></script>
+        <span><xmp><&></xmp></span>
+        <span><iframe><&></iframe></span>
+        <span><noembed><&></noembed></span>
+        <span><noframes><&></noframes></span>
+        <span><noscript><&></noscript></span>
+        <span><!--data--></span>
+        <span><a><b><c></c></b><d>e</d><f><g>h</g></f></a></span>
+        <span b=c></span>
+        </div>
+        EOF
+      Nokogiri::HTML5(html).xpath('/html/body/div/*')
+    end
+    @serializing_test_data
+  end
+
+  EXPECTED = [
+    ["", "<span></span>"],
+    ["<a></a>", "<span><a></a></span>"],
+    ["<a b=\"c\"></a>", "<span><a b=\"c\"></a></span>"],
+    ["<a b=\"c\"></a>", "<span><a b=\"c\"></a></span>"],
+    ["<a b=\"&amp;\"></a>", "<span><a b=\"&amp;\"></a></span>"],
+    ["<a b=\"&nbsp;\"></a>", "<span><a b=\"&nbsp;\"></a></span>"],
+    ["<a b=\"&quot;\"></a>", "<span><a b=\"&quot;\"></a></span>"],
+    ["<a b=\"<\"></a>", "<span><a b=\"<\"></a></span>"],
+    ["<a b=\">\"></a>", "<span><a b=\">\"></a></span>"],
+    ["<svg xlink:href=\"a\"></svg>", "<span><svg xlink:href=\"a\"></svg></span>"],
+    ["<svg xmlns:svg=\"test\"></svg>", "<span><svg xmlns:svg=\"test\"></svg></span>"],
+    ["a", "<span>a</span>"],
+    ["&amp;", "<span>&amp;</span>"],
+    ["&nbsp;", "<span>&nbsp;</span>"],
+    ["&lt;", "<span>&lt;</span>"],
+    ["&gt;", "<span>&gt;</span>"],
+    ["\"", "<span>\"</span>"],
+    ["<style><&></style>", "<span><style><&></style></span>"],
+    ["<script type=\"test\"><&><\/script>", "<span><script type=\"test\"><&><\/script></span>"],
+    ["<&>", "<script type=\"test\"><&><\/script>"],
+    ["<xmp><&></xmp>", "<span><xmp><&></xmp></span>"],
+    ["<iframe><&></iframe>", "<span><iframe><&></iframe></span>"],
+    ["<noembed><&></noembed>", "<span><noembed><&></noembed></span>"],
+    ["<noframes><&></noframes>", "<span><noframes><&></noframes></span>"],
+    ["<noscript><&></noscript>", "<span><noscript><&></noscript></span>"],
+    ["<!--data-->", "<span><!--data--></span>"],
+    ["<a><b><c></c></b><d>e</d><f><g>h</g></f></a>", "<span><a><b><c></c></b><d>e</d><f><g>h</g></f></a></span>"],
+    ["", "<span b=\"c\"></span>"]
+  ].freeze
+
+  DOM_TESTS = [
+    ['Attribute in the XML namespace',
+      lambda do
+        doc = Nokogiri::HTML5::Document.new
+        span = Nokogiri::XML::Node.new('span', doc)
+        svg = Nokogiri::XML::Node.new('svg', doc)
+        span.add_child(svg)
+        svg.add_namespace('xml', 'http://www.w3.org/XML/1998/namespace')
+        svg['xml:foo'] = 'test'
+        span
+      end,
+      '<svg xml:foo="test"></svg>',
+      '<span><svg xml:foo="test"></svg></span>'],
+
+    ["Attribute in the XML namespace with the prefix not set to xml:",
+      lambda do
+        doc = Nokogiri::HTML5::Document.new
+        span = Nokogiri::XML::Node.new('span', doc)
+        svg = Nokogiri::XML::Node.new('svg', doc)
+        span.add_child(svg)
+        svg['abc:foo'] = 'test'
+        ns = svg.add_namespace('xml', 'http://www.w3.org/XML/1998/namespace')
+        svg.attribute('abc:foo').namespace = ns
+        span
+      end,
+      '<svg xml:foo="test"></svg>',
+      '<span><svg xml:foo="test"></svg></span>'],
+
+    ["Non-'xmlns' attribute in the xmlns namespace",
+      lambda do
+        doc = Nokogiri::HTML5::Document.new
+        span = Nokogiri::XML::Node.new('span', doc)
+        svg = Nokogiri::XML::Node.new('svg', doc)
+        span.add_child(svg)
+        svg.add_namespace('xmlns', 'http://www.w3.org/2000/xmlns/')
+        svg['xmlns:foo'] = 'test'
+        span
+      end,
+      '<svg xmlns:foo="test"></svg>',
+      '<span><svg xmlns:foo="test"></svg></span>'],
+
+    ["'xmlns' attribute in the xmlns namespace",
+      lambda do
+        doc = Nokogiri::HTML5::Document.new
+        span = Nokogiri::XML::Node.new('span', doc)
+        svg = Nokogiri::XML::Node.new('svg', doc)
+        span.add_child(svg)
+        svg.add_namespace('xmlns', 'http://www.w3.org/2000/xmlns/')
+        svg['xmlns'] = 'test'
+        span
+      end,
+      '<svg xmlns="test"></svg>',
+      '<span><svg xmlns="test"></svg></span>'],
+
+    ["Attribute in non-standard namespace",
+      lambda do
+        doc = Nokogiri::HTML5::Document.new
+        span = Nokogiri::XML::Node.new('span', doc)
+        svg = Nokogiri::XML::Node.new('svg', doc)
+        span.add_child(svg)
+        svg.add_namespace('abc', 'fake_ns')
+        svg['abc:def'] = 'test'
+        span
+      end,
+      '<svg abc:def="test"></svg>',
+      '<span><svg abc:def="test"></svg></span>'],
+
+    ["<span> starting with U+000A",
+      lambda do
+        doc = Nokogiri::HTML5::Document.new
+        span = Nokogiri::XML::Node.new('span', doc)
+        text = Nokogiri::XML::Text.new("\x0A", doc)
+        span.add_child(text)
+        span
+      end,
+      "\x0A",
+      "<span>\x0A</span>"],
+    #TODO: Processing instructions
+  ]
+
+  TEXT_ELEMENTS = %w[pre textarea listing]
+  TEXT_TESTS = [
+    ["<%text> context starting with U+000A",
+      lambda do |tag|
+        doc = Nokogiri::HTML5::Document.new
+        elem = Nokogiri::XML::Node.new(tag, doc)
+        text = Nokogiri::XML::Text.new("\x0A", doc)
+        elem.add_child(text)
+        elem
+      end,
+     "\x0A",
+     "<%text>\x0A</%text>"],
+
+    ["<%text> context not starting with U+000A",
+      lambda do |tag|
+        doc = Nokogiri::HTML5::Document.new
+        elem = Nokogiri::XML::Node.new(tag, doc)
+        text = Nokogiri::XML::Text.new("a\x0A", doc)
+        elem.add_child(text)
+        elem
+      end,
+     "a\x0A",
+     "<%text>a\x0A</%text>"],
+
+    ["<%text> non-context starting with U+000A",
+      lambda do |tag|
+        doc = Nokogiri::HTML5::Document.new
+        elem = Nokogiri::XML::Node.new(tag, doc)
+        span = Nokogiri::XML::Node.new('span', doc)
+        text = Nokogiri::XML::Text.new("\x0A", doc)
+        elem.add_child(text)
+        span.add_child(elem)
+        span
+      end,
+     "<%text>\x0A</%text>",
+     "<span><%text>\x0A</%text></span>"],
+
+    ["<%text> non-context not starting with U+000A",
+      lambda do |tag|
+        doc = Nokogiri::HTML5::Document.new
+        elem = Nokogiri::XML::Node.new(tag, doc)
+        span = Nokogiri::XML::Node.new('span', doc)
+        text = Nokogiri::XML::Text.new("a\x0A", doc)
+        elem.add_child(text)
+        span.add_child(elem)
+        span
+      end,
+     "<%text>a\x0A</%text>",
+     "<span><%text>a\x0A</%text></span>"],
+  ]
+
+  VOID_ELEMENTS = [
+    "area", "base", "basefont", "bgsound", "br", "col", "embed",
+    "frame", "hr", "img", "input", "keygen", "link",
+    "meta", "param", "source", "track", "wbr"
+  ]
+  VOID_TESTS = [
+    ["Void context node",
+      lambda do |tag|
+        doc = Nokogiri::HTML5::Document.new
+        Nokogiri::XML::Node.new(tag, doc)
+      end,
+      "",
+      "<%void>"],
+
+    ["void as first child with following siblings",
+      lambda do |tag|
+        doc = Nokogiri::HTML5::Document.new
+        span = Nokogiri::XML::Node.new('span', doc)
+        span.add_child(Nokogiri::XML::Node.new(tag, doc))
+        span.add_child(Nokogiri::XML::Node.new('a', doc))
+          .add_child(Nokogiri::XML::Text.new('test', doc))
+        span.add_child(Nokogiri::XML::Node.new('b', doc))
+        span
+      end,
+      "<%void><a>test</a><b></b>",
+      "<span><%void><a>test</a><b></b></span>"
+     ],
+
+    ["void as second child with following siblings",
+      lambda do |tag|
+        doc = Nokogiri::HTML5::Document.new
+        span = Nokogiri::XML::Node.new('span', doc)
+        span.add_child(Nokogiri::XML::Node.new('a', doc))
+          .add_child(Nokogiri::XML::Text.new('test', doc))
+        span.add_child(Nokogiri::XML::Node.new(tag, doc))
+        span.add_child(Nokogiri::XML::Node.new('b', doc))
+        span
+      end,
+      "<a>test</a><%void><b></b>",
+      "<span><a>test</a><%void><b></b></span>"
+     ],
+    ["void as last child with preceding siblings",
+      lambda do |tag|
+        doc = Nokogiri::HTML5::Document.new
+        span = Nokogiri::XML::Node.new('span', doc)
+        span.add_child(Nokogiri::XML::Node.new('a', doc))
+          .add_child(Nokogiri::XML::Text.new('test', doc))
+        span.add_child(Nokogiri::XML::Node.new('b', doc))
+        span.add_child(Nokogiri::XML::Node.new(tag, doc))
+        span
+      end,
+      "<a>test</a><b></b><%void>",
+      "<span><a>test</a><b></b><%void></span>"
+    ],
+  ]
+
+
+  # Generate tests
+  def self.cross_map(a1, a2)
+    rv = []
+    a1.each do |a1_elem|
+      a2.each do |a2_elem|
+        rv << yield(a1_elem, a2_elem)
+      end
+    end
+  end
+
+  EXPECTED.each_with_index do |item, i|
+    define_method("test_serializing_html_innerHTML_#{i}".to_sym) do
+      assert_equal item[0], serializing_test_data[i].inner_html
+    end
+
+    define_method("test_serializing_html_outerHTML_#{i}".to_sym) do
+      assert_equal item[1], serializing_test_data[i].serialize
+    end
+  end
+
+  DOM_TESTS.each do |test|
+    define_method("test_serializing_dom_innerHTML_#{test[0]}".to_sym) do
+      elem = test[1].call
+      refute_nil elem
+      assert_equal test[2], elem.inner_html
+    end
+
+    define_method("test_serializing_dom_outerHTML_#{test[0]}".to_sym) do
+      elem = test[1].call
+      refute_nil elem
+      assert_equal test[3], elem.serialize
+    end
+  end
+
+  cross_map(TEXT_TESTS, TEXT_ELEMENTS) do |test_data, tag|
+    define_method("test_serializing_text_innerHTML_#{test_data[0].gsub('%text', tag)}".to_sym) do
+      assert_equal test_data[2].gsub('%text', tag), test_data[1].call(tag).inner_html
+    end
+
+    define_method("test_serialization_text_outerHTML_#{test_data[0].gsub('%text', tag)}".to_sym) do
+      assert_equal test_data[3].gsub('%text', tag), test_data[1].call(tag).serialize
+    end
+  end
+
+  cross_map(VOID_TESTS, VOID_ELEMENTS) do |test_data, tag|
+    define_method("test_serializing_void_innerHTML_#{test_data[0]}_#{tag}".to_sym) do
+      assert_equal test_data[2].gsub('%void', tag), test_data[1].call(tag).inner_html
+    end
+
+    define_method("test_serialization_void_outerHTML_#{test_data[0]}_#{tag}".to_sym) do
+      assert_equal test_data[3].gsub('%void', tag), test_data[1].call(tag).serialize
+    end
+  end
+end


### PR DESCRIPTION
The various serialization APIs follow the standard for serializing HTML
fragments. As an extension, multiple newlines at the beginning of a
`<pre>`, `<textedit>`, and `<listing>` can be preserved using the
`preserve_newline: true` option to the serializing functions that take
options.

Closes: #14