### PR TITLE
Support serialization option on document fragments.

### DIFF
--- a/lib/nokogumbo/html5.rb
+++ b/lib/nokogumbo/html5.rb
@@ -220,7 +220,7 @@ module Nokogiri
         io << '<?' << current_node.content << '>'
       when XML::Node::DOCUMENT_TYPE_NODE, XML::Node::DTD_NODE
           io << '<!DOCTYPE ' << current_node.name << '>'
-      when XML::Node::HTML_DOCUMENT_NODE
+      when XML::Node::HTML_DOCUMENT_NODE, XML::Node::DOCUMENT_FRAG_NODE
         current_node.children.each do |child|
           serialize_node_internal(child, io, encoding, options)
         end

--- a/lib/nokogumbo/html5/document_fragment.rb
+++ b/lib/nokogumbo/html5/document_fragment.rb
@@ -28,6 +28,12 @@ module Nokogiri
         end
       end
 
+      def serialize(options = {}, &block)
+        # Bypass XML::Document.serialize which doesn't support options even
+        # though XML::Node.serialize does!
+        XML::Node.instance_method(:serialize).bind(self).call(options, &block)
+      end
+
       # Parse a document fragment from +tags+, returning a Nodeset.
       def self.parse(tags, encoding = nil, options = {})
         doc = HTML5::Document.new

--- a/test/test_api.rb
+++ b/test/test_api.rb
@@ -61,6 +61,14 @@ class TestAPI < Minitest::Test
     assert_match(/おはようございます/, Nokogiri::HTML5::DocumentFragment.parse(raw, Encoding::SHIFT_JIS).to_s)
   end
 
+  def test_fragment_serialization_encoding
+    frag = Nokogiri::HTML5.fragment('<span>아는 길도 물어가라</span>')
+    html = frag.serialize(encoding: 'US-ASCII')
+    assert_equal '<span>&#xc544;&#xb294; &#xae38;&#xb3c4; &#xbb3c;&#xc5b4;&#xac00;&#xb77c;</span>', html
+    frag = Nokogiri::HTML5.fragment(html)
+    assert_equal '<span>아는 길도 물어가라</span>', frag.serialize
+  end
+
   def test_serialization_encoding
     html = '<!DOCUMENT html><span>ฉันไม่พูดภาษาไทย</span>'
     doc = Nokogiri::HTML5(html)


### PR DESCRIPTION
`Nokogiri::XML::DocumentFragment` overrides `Nokogiri::XML::Node.serialize` by making it an alias for `#to_s`. There's no good reason to do that.