### PR TITLE
Finish the fragment parser implementation

### DIFF
--- a/gumbo-parser/src/string_piece.c
+++ b/gumbo-parser/src/string_piece.c
@@ -20,11 +20,6 @@
 #include "gumbo.h"
 #include "ascii.h"
 
-const GumboStringPiece kGumboEmptyString = { \
-  .data = NULL, \
-  .length = 0 \
-};
-
 bool gumbo_string_equals (
   const GumboStringPiece* str1,
   const GumboStringPiece* str2
@@ -41,4 +36,13 @@ bool gumbo_string_equals_ignore_case (
   return
     str1->length == str2->length
     && !gumbo_ascii_strncasecmp(str1->data, str2->data, str1->length);
+}
+
+bool gumbo_string_prefix_ignore_case (
+  const GumboStringPiece* prefix,
+  const GumboStringPiece* str
+) {
+  return
+    prefix->length <= str->length
+    && !gumbo_ascii_strncasecmp(prefix->data, str->data, prefix->length);
 }

--- a/gumbo-parser/src/vector.c
+++ b/gumbo-parser/src/vector.c
@@ -21,12 +21,6 @@
 #include "vector.h"
 #include "util.h"
 
-const GumboVector kGumboEmptyVector = { \
-  .data = NULL, \
-  .length = 0, \
-  .capacity = 0 \
-};
-
 void gumbo_vector_init(unsigned int initial_capacity, GumboVector* vector) {
   vector->length = 0;
   vector->capacity = initial_capacity;


### PR DESCRIPTION
It's not enough to parse a fragment based on a known tag and namespace.
The the five pieces of information required are
1. the context element tag name;
2. the context element tag namespace;
3. the value of the context element's `encoding` attribute (when the
   element is an MathML `annotation-xml` element);
4. the quirks mode of the host document; and
5. the form element pointer.

The `encoding` attribute of an `annotation-xml` context element
determines if the content should be parsed as HTML or as foreign
elements. See
https://html.spec.whatwg.org/multipage/parsing.html#html-integration-point

Broken DOCTYPE declartions can put the document in quirks mode in
addition to specific public and system identifiers. libxml2 has no way
to record the `force-quirks flag`
https://html.spec.whatwg.org/multipage/parsing.html#force-quirks-flag
Fortunately, the quirks mode plays very little role in parsing.

Finally, if the fragment context is a form element (or has one as an
ancestor), then `<form>` and `</form>` tags (among other things) are
parse errors and the tags are ignored.