### PR TITLE
Better monkey patching with prepend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   in the SVG or MathML namespaces)**. On HTML elements, this creates an
   attribute with the name `xml:lang`. This changes the `#xpath` and related
   APIs.
+- Calling `#to_xml` on a `Nokogiri::HTML5::Document` will produce XML output
+  rather than HTML.
 
 ### Deprecated
 - `:max_parse_errors`; use `:max_errors`

--- a/lib/nokogumbo.rb
+++ b/lib/nokogumbo.rb
@@ -1,7 +1,6 @@
 require 'nokogiri'
 require 'nokogumbo/version'
 require 'nokogumbo/html5'
-require 'nokogumbo/xml/node.rb'
 
 require 'nokogumbo/nokogumbo'
 

--- a/lib/nokogumbo/html5.rb
+++ b/lib/nokogumbo/html5.rb
@@ -1,5 +1,6 @@
 require 'nokogumbo/html5/document'
 require 'nokogumbo/html5/document_fragment'
+require 'nokogumbo/html5/node'
 
 module Nokogiri
   # Parse an HTML 5 document. Convenience method for Nokogiri::HTML5::Document.parse

--- a/lib/nokogumbo/html5/document.rb
+++ b/lib/nokogumbo/html5/document.rb
@@ -28,6 +28,12 @@ module Nokogiri
         DocumentFragment.new(self, tags, self.root)
       end
 
+      def to_xml(options = {}, &block)
+        # Bypass XML::Document#to_xml which doesn't add
+        # XML::Node::SaveOptions::AS_XML like XML::Node#to_xml does.
+        XML::Node.instance_method(:to_xml).bind(self).call(options, &block)
+      end
+
       private
       def self.do_parse(string_or_io, url, encoding, options)
         string = HTML5.read_and_encode(string_or_io, encoding)

--- a/test/test_monkey_patch.rb
+++ b/test/test_monkey_patch.rb
@@ -1,0 +1,16 @@
+# encoding: utf-8
+require 'nokogumbo'
+require 'minitest/autorun'
+
+class TestNokogumbo < Minitest::Test
+  def test_to_xml
+    xml = Nokogiri.HTML5('<!DOCTYPE html><source>').to_xml
+    assert_match(/\A<\?xml version/, xml)
+    assert_match(/<source\s*\/>/, xml)
+  end
+
+  def test_html4_fragment
+    frag = Nokogiri::HTML.fragment('<span></span>')
+    assert frag.is_a?(Nokogiri::HTML::DocumentFragment)
+  end
+end


### PR DESCRIPTION
Rather than reopen and modify methods in `Nokogiri::XML::Node`, this
defines a new module `Nokogiri::HTML5::Node` and prepends those methods
to `Nokogiri::XML::Node`. Each of them checks that the node's
controlling document is a `Nokogiri::HTML5::Document` and if not, calls
the corresponding Nokogiri method.

Additionally, forward `Nokogiri::HTML5::Document#to_xml` to
`Nokogiri::XML::Node#to_xml` because otherwise
`Nokogiri::XML::Document#to_xml` will be called which is an alias for
`#serialize` and that doesn't add the `AS_XML` option. The upshot is
that `Nokogiri.HTML5(html).to_xml` will output XML whereas
`Nokogiri.HTML(html).to_xml` will output (old) HTML.