### PR TITLE
Fix memory leak with end tags

### DIFF
--- a/gumbo-parser/src/parser.c
+++ b/gumbo-parser/src/parser.c
@@ -4671,6 +4671,8 @@ GumboOutput* gumbo_parse_with_options (
     );
 
     if (!state->_reprocess_current_token) {
+      // If we're done with the token, check for unacknowledged self-closing
+      // flags on start tags and any self-closing flags on end tags.
       if (token.type == GUMBO_TOKEN_START_TAG &&
           token.v.start_tag.is_self_closing &&
           !state->_self_closing_flag_acknowledged) {
@@ -4684,6 +4686,11 @@ GumboOutput* gumbo_parse_with_options (
         if (error)
           error->type = GUMBO_ERR_SELF_CLOSING_END_TAG;
       }
+      // Make sure we free the end tag's name since it doesn't get transferred
+      // to a token.
+      if (token.type == GUMBO_TOKEN_END_TAG &&
+	  token.v.end_tag.tag == GUMBO_TAG_UNKNOWN)
+        gumbo_free(token.v.end_tag.name);
     }
 
     if (unlikely(state->_open_elements.length > max_tree_depth)) {

--- a/gumbo-parser/src/tokenizer.c
+++ b/gumbo-parser/src/tokenizer.c
@@ -3285,12 +3285,16 @@ void gumbo_token_destroy(GumboToken* token) {
         }
       }
       gumbo_free((void*) token->v.start_tag.attributes.data);
-      if (token->v.start_tag.tag == GUMBO_TAG_UNKNOWN)
+      if (token->v.start_tag.tag == GUMBO_TAG_UNKNOWN) {
         gumbo_free(token->v.start_tag.name);
+        token->v.start_tag.name = NULL;
+      }
       return;
     case GUMBO_TOKEN_END_TAG:
-      if (token->v.end_tag.tag == GUMBO_TAG_UNKNOWN)
+      if (token->v.end_tag.tag == GUMBO_TAG_UNKNOWN) {
         gumbo_free(token->v.end_tag.name);
+        token->v.end_tag.name = NULL;
+      }
       break;
     case GUMBO_TOKEN_COMMENT:
       gumbo_free((void*) token->v.text);


### PR DESCRIPTION
End tags with GUMBO_TAG_UNKNOWN that aren't ignored were leaking because
the tokens were not otherwise destroyed. (Non-ignored start tags
transfer all of their allocated memory to the corresponding tokens.)

Explicitly deallocate names for end tags. When ignoring (or otherwise
destroying), set the name fields to NULL.

This fixes the remaining memory leaks when running the unit tests.