### PR TITLE
Fix dependencies.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,6 +14,7 @@ task gem: :test
 
 ext = Rake::ExtensionTask.new 'nokogumbo' do |e|
   e.lib_dir = 'lib/nokogumbo'
+  e.source_pattern = '../../gumbo-parser/src/*.[hc]'
 end
 
 Rake::TestTask.new(:test) do |t|

--- a/ext/nokogumbo/extconf.rb
+++ b/ext/nokogumbo/extconf.rb
@@ -108,9 +108,14 @@ gumbo_src = File.join(ext_dir, 'gumbo_src')
 
 Dir.chdir(ext_dir) do
   $srcs = Dir['*.c', '../../gumbo-parser/src/*.c']
+  $hdrs = Dir['*.h', '../../gumbo-parser/src/*.h']
 end
 $INCFLAGS << ' -I$(srcdir)/../../gumbo-parser/src'
 $VPATH << '$(srcdir)/../../gumbo-parser/src'
 
-create_makefile('nokogumbo/nokogumbo')
+create_makefile('nokogumbo/nokogumbo') do |conf|
+  conf.map! do |chunk|
+    chunk.gsub(/^HDRS = .*$/, "HDRS = #{$hdrs.map { |h| File.join('$(srcdir)', h)}.join(' ')}")
+  end
+end
 # vim: set sw=2 sts=2 ts=8 et:


### PR DESCRIPTION
Without this, modifying the gumbo files doesn't trigger a rebuild of the extension.