### PR TITLE
Simplify temporary buffer usage

### DIFF
--- a/gumbo-parser/src/utf8.h
+++ b/gumbo-parser/src/utf8.h
@@ -111,6 +111,11 @@ const char* utf8iterator_get_char_pointer(const Utf8Iterator* iter);
 // decoder.
 const char* utf8iterator_get_end_pointer(const Utf8Iterator* iter);
 
+// Retrieves a character pointer to the marked position.
+static inline const char* utf8iterator_get_mark_pointer(const Utf8Iterator* iter) {
+  return iter->_mark;
+}
+
 // If the upcoming text in the buffer matches the specified prefix (which has
 // length 'length'), consume it and return true. Otherwise, return false with
 // no other effects. If the length of the string would overflow the buffer,


### PR DESCRIPTION
Previously, we would insert characters into the temporary buffer for two
reasons:
1. To keep track of text we'd seen and moved beyond but had not emitted
   as character tokens in order to emit them later; and
2. Record strings for comments and doctypes.

Use 1 was a bit silly because in order to get the correct token
positions, we would mark the input stream when clearing the temporary
buffer, reset the input to the mark, and then advance the input and a
pointer into the temporary buffer in lock step, emitting character
tokens.

Now we just mark the input stream, and then begin emitting from the mark
point as needed.

This has the advantage that it frees us to use the temporary buffer for
recording the escaped `script` tag rather than the `_script_data_buffer`
which is now removed.