### PR TITLE
Standardize errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ matrix:
       rvm: 2.5
       script: scripts/ci-package-test.sh
 
-install: git clone --depth 1 --branch master --single-branch https://github.com/html5lib/html5lib-tests.git test/html5lib-tests
+#install: git clone --depth 1 --branch master --single-branch https://github.com/html5lib/html5lib-tests.git test/html5lib-tests
+install: git clone --depth 1 --branch all-error-fixes --single-branch https://github.com/stevecheckoway/html5lib-tests.git test/html5lib-tests
 script: scripts/ci-test.sh
 cache: bundler

--- a/Rakefile
+++ b/Rakefile
@@ -14,7 +14,7 @@ task gem: :test
 
 ext = Rake::ExtensionTask.new 'nokogumbo' do |e|
   e.lib_dir = 'lib/nokogumbo'
-  e.source_pattern = '../../gumbo-parser/src/*.[hc]'
+  e.source_pattern = '{,../../gumbo-parser/src/}*.[hc]'
 end
 
 Rake::TestTask.new(:test) do |t|

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,8 @@ install:
   - bundle --version
   - bundle install --path vendor/bundle
   - bundle exec nokogiri --version
-  - git clone --depth 1 --branch master --single-branch https://github.com/html5lib/html5lib-tests.git test/html5lib-tests
+  - git clone --depth 1 --branch all-error-fixes --single-branch https://github.com/stevecheckoway/html5lib-tests.git test/html5lib-tests
+  #- git clone --depth 1 --branch master --single-branch https://github.com/html5lib/html5lib-tests.git test/html5lib-tests
 
 build: off
 

--- a/ext/nokogumbo/nokogumbo.c
+++ b/ext/nokogumbo/nokogumbo.c
@@ -20,6 +20,9 @@
 
 #include <assert.h>
 #include <ruby.h>
+#include <ruby/encoding.h>
+#include <ruby/version.h>
+
 #include "gumbo.h"
 #include "error.h"
 
@@ -29,6 +32,21 @@ static VALUE Document;
 // Interned symbols
 static ID internal_subset;
 static ID parent;
+
+/* Backwards compatibility to Ruby 2.1.0 */
+#if RUBY_API_VERSION_CODE < 20200
+static VALUE rb_utf8_str_new_cstr(const char *str) {
+  return rb_enc_str_new_cstr(str, rb_utf8_encoding());
+}
+
+static VALUE rb_utf8_str_new(const char *str, long length) {
+  return rb_enc_str_new(str, length, rb_utf8_encoding());
+}
+
+static VALUE rb_utf8_str_new_static(const char *str, long length) {
+  return rb_enc_str_new_static(str, length, rb_utf8_encoding());
+}
+#endif
 
 #if NGLIB
 #include <nokogiri.h>

--- a/gumbo-parser/src/error.c
+++ b/gumbo-parser/src/error.c
@@ -19,6 +19,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 #include <string.h>
+#include "ascii.h"
 #include "error.h"
 #include "gumbo.h"
 #include "macros.h"
@@ -45,13 +46,13 @@ static int PRINTF(2) print_message (
     args
   );
   va_end(args);
-#ifdef _MSC_VER
+#if _MSC_VER && _MSC_VER < 1900
   if (bytes_written == -1) {
-    // vsnprintf returns -1 on MSVC++ if there's not enough capacity, instead of
-    // returning the number of bytes that would've been written had there been
-    // enough. In this case, we'll double the buffer size and hope it fits when
-    // we retry (letting it fail and returning 0 if it doesn't), since there's
-    // no way to smartly resize the buffer.
+    // vsnprintf returns -1 on older MSVC++ if there's not enough capacity,
+    // instead of returning the number of bytes that would've been written had
+    // there been enough. In this case, we'll double the buffer size and hope
+    // it fits when we retry (letting it fail and returning 0 if it doesn't),
+    // since there's no way to smartly resize the buffer.
     gumbo_string_buffer_reserve(output->capacity * 2, output);
     va_start(args, format);
     int result = vsnprintf (
@@ -101,6 +102,214 @@ static void print_tag_stack (
   gumbo_string_buffer_append_codepoint('.', output);
 }
 
+static void handle_tokenizer_error (
+  const GumboError* error,
+  GumboStringBuffer* output
+) {
+  switch (error->type) {
+  case GUMBO_ERR_ABRUPT_CLOSING_OF_EMPTY_COMMENT:
+      print_message(output, "Empty comment abruptly closed by '%s', use '-->'.",
+                    error->v.tokenizer.state == GUMBO_LEX_COMMENT_START? ">" : "->");
+    break;
+  case GUMBO_ERR_ABRUPT_DOCTYPE_PUBLIC_IDENTIFIER:
+    print_message (
+      output,
+      "DOCTYPE public identifier missing closing %s.",
+      error->v.tokenizer.state == GUMBO_LEX_DOCTYPE_PUBLIC_ID_DOUBLE_QUOTED?
+        "quotation mark (\")" : "apostrophe (')"
+    );
+    break;
+  case GUMBO_ERR_ABRUPT_DOCTYPE_SYSTEM_IDENTIFIER:
+    print_message (
+      output,
+      "DOCTYPE system identifier missing closing %s.",
+      error->v.tokenizer.state == GUMBO_LEX_DOCTYPE_SYSTEM_ID_DOUBLE_QUOTED?
+        "quotation mark (\")" : "apostrophe (')"
+    );
+    break;
+  case GUMBO_ERR_ABSENCE_OF_DIGITS_IN_NUMERIC_CHARACTER_REFERENCE:
+    print_message (
+      output,
+      "Numeric character reference '%.*s' does not contain any %sdigits.",
+      (int)error->original_text.length, error->original_text.data,
+      error->v.tokenizer.state == GUMBO_LEX_HEXADECIMAL_CHARACTER_REFERENCE_START? "hexadecimal " : ""
+    );
+    break;
+  case GUMBO_ERR_CDATA_IN_HTML_CONTENT:
+    print_message(output, "CDATA section outside foreign (SVG or MathML) content.");
+    break;
+  case GUMBO_ERR_CHARACTER_REFERENCE_OUTSIDE_UNICODE_RANGE:
+    print_message (
+      output,
+      "Numeric character reference '%.*s' references a code point that is outside the valid Unicode range.",
+      (int)error->original_text.length, error->original_text.data
+    );
+    break;
+  case GUMBO_ERR_CONTROL_CHARACTER_IN_INPUT_STREAM:
+    print_message (
+      output,
+      "Input contains prohibited control code point U+%04X.",
+      error->v.tokenizer.codepoint
+    );
+    break;
+  case GUMBO_ERR_CONTROL_CHARACTER_REFERENCE:
+    print_message (
+      output,
+      "Numeric character reference '%.*s' references prohibited control code point U+%04X.",
+      (int)error->original_text.length, error->original_text.data,
+      error->v.tokenizer.codepoint
+    );
+    break;
+  case GUMBO_ERR_END_TAG_WITH_ATTRIBUTES:
+    print_message(output, "End tag contains attributes.");
+    break;
+  case GUMBO_ERR_DUPLICATE_ATTRIBUTE:
+    print_message(output, "Tag contains multiple attributes with the same name.");
+    break;
+  case GUMBO_ERR_END_TAG_WITH_TRAILING_SOLIDUS:
+    print_message(output, "End tag ends with '/>', use '>'.");
+    break;
+  case GUMBO_ERR_EOF_BEFORE_TAG_NAME:
+    print_message(output, "End of input where a tag name is expected.");
+    break;
+  case GUMBO_ERR_EOF_IN_CDATA:
+    print_message(output, "End of input in CDATA section.");
+    break;
+  case GUMBO_ERR_EOF_IN_COMMENT:
+    print_message(output, "End of input in comment.");
+    break;
+  case GUMBO_ERR_EOF_IN_DOCTYPE:
+    print_message(output, "End of input in DOCTYPE.");
+    break;
+  case GUMBO_ERR_EOF_IN_SCRIPT_HTML_COMMENT_LIKE_TEXT:
+    print_message(output, "End of input in text that resembles an HTML comment inside script element content.");
+    break;
+  case GUMBO_ERR_EOF_IN_TAG:
+    print_message(output, "End of input in tag.");
+    break;
+  case GUMBO_ERR_INCORRECTLY_CLOSED_COMMENT:
+    print_message(output, "Comment closed incorrectly by '--!>', use '-->'.");
+    break;
+  case GUMBO_ERR_INCORRECTLY_OPENED_COMMENT:
+    print_message(output, "Comment, DOCTYPE, or CDATA opened incorrectly, use '<!--', '<!DOCTYPE', or '<![CDATA['.");
+    break;
+  case GUMBO_ERR_INVALID_CHARACTER_SEQUENCE_AFTER_DOCTYPE_NAME:
+    print_message(output, "Invalid character sequence after DOCTYPE name, expected 'PUBLIC', 'SYSTEM', or '>'.");
+    break;
+  case GUMBO_ERR_INVALID_FIRST_CHARACTER_OF_TAG_NAME:
+    if (gumbo_ascii_isascii(error->v.tokenizer.codepoint)
+        && !gumbo_ascii_iscntrl(error->v.tokenizer.codepoint))
+      print_message(output, "Invalid first character of tag name '%c'.", error->v.tokenizer.codepoint);
+    else
+      print_message(output, "Invalid first code point of tag name U+%04X.", error->v.tokenizer.codepoint);
+    break;
+  case GUMBO_ERR_MISSING_ATTRIBUTE_VALUE:
+    print_message(output, "Missing attribute value.");
+    break;
+  case GUMBO_ERR_MISSING_DOCTYPE_NAME:
+    print_message(output, "Missing DOCTYPE name.");
+    break;
+  case GUMBO_ERR_MISSING_DOCTYPE_PUBLIC_IDENTIFIER:
+    print_message(output, "Missing DOCTYPE public identifier.");
+    break;
+  case GUMBO_ERR_MISSING_DOCTYPE_SYSTEM_IDENTIFIER:
+    print_message(output, "Missing DOCTYPE system identifier.");
+    break;
+  case GUMBO_ERR_MISSING_END_TAG_NAME:
+    print_message(output, "Missing end tag name.");
+    break;
+  case GUMBO_ERR_MISSING_QUOTE_BEFORE_DOCTYPE_PUBLIC_IDENTIFIER:
+    print_message(output, "Missing quote before DOCTYPE public identifier.");
+    break;
+  case GUMBO_ERR_MISSING_QUOTE_BEFORE_DOCTYPE_SYSTEM_IDENTIFIER:
+    print_message(output, "Missing quote before DOCTYPE system identifier.");
+    break;
+  case GUMBO_ERR_MISSING_SEMICOLON_AFTER_CHARACTER_REFERENCE:
+    print_message(output, "Missing semicolon after character reference '%.*s'.",
+                  (int)error->original_text.length, error->original_text.data);
+    break;
+  case GUMBO_ERR_MISSING_WHITESPACE_AFTER_DOCTYPE_PUBLIC_KEYWORD:
+    print_message(output, "Missing whitespace after 'PUBLIC' keyword.");
+    break;
+  case GUMBO_ERR_MISSING_WHITESPACE_AFTER_DOCTYPE_SYSTEM_KEYWORD:
+    print_message(output, "Missing whitespace after 'SYSTEM' keyword.");
+    break;
+  case GUMBO_ERR_MISSING_WHITESPACE_BEFORE_DOCTYPE_NAME:
+    print_message(output, "Missing whitespace between 'DOCTYPE' keyword and DOCTYPE name.");
+    break;
+  case GUMBO_ERR_MISSING_WHITESPACE_BETWEEN_ATTRIBUTES:
+    print_message(output, "Missing whitespace between attributes.");
+    break;
+  case GUMBO_ERR_MISSING_WHITESPACE_BETWEEN_DOCTYPE_PUBLIC_AND_SYSTEM_IDENTIFIERS:
+    print_message(output, "Missing whitespace between DOCTYPE public and system identifiers.");
+    break;
+  case GUMBO_ERR_NESTED_COMMENT:
+    print_message(output, "Nested comment.");
+    break;
+  case GUMBO_ERR_NONCHARACTER_CHARACTER_REFERENCE:
+    print_message (
+      output,
+      "Numeric character reference '%.*s' references noncharacter U+%04X.",
+      (int)error->original_text.length, error->original_text.data,
+      error->v.tokenizer.codepoint
+    );
+    break;
+  case GUMBO_ERR_NONCHARACTER_IN_INPUT_STREAM:
+    print_message(output, "Input contains noncharacter U+%04X.", error->v.tokenizer.codepoint);
+    break;
+  case GUMBO_ERR_NON_VOID_HTML_ELEMENT_START_TAG_WITH_TRAILING_SOLIDUS:
+    print_message(output, "Start tag of nonvoid HTML element ends with '/>', use '>'.");
+    break;
+  case GUMBO_ERR_NULL_CHARACTER_REFERENCE:
+    print_message(output, "Numeric character reference '%.*s' references U+0000.",
+                  (int)error->original_text.length, error->original_text.data);
+    break;
+  case GUMBO_ERR_SURROGATE_CHARACTER_REFERENCE:
+    print_message (
+      output,
+      "Numeric character reference '%.*s' references surrogate U+%4X.",
+      (int)error->original_text.length, error->original_text.data,
+      error->v.tokenizer.codepoint
+    );
+    break;
+  case GUMBO_ERR_SURROGATE_IN_INPUT_STREAM:
+    print_message(output, "Input contains surrogate U+%04X.", error->v.tokenizer.codepoint);
+    break;
+  case GUMBO_ERR_UNEXPECTED_CHARACTER_AFTER_DOCTYPE_SYSTEM_IDENTIFIER:
+    print_message(output, "Unexpected character after DOCTYPE system identifier.");
+    break;
+  case GUMBO_ERR_UNEXPECTED_CHARACTER_IN_ATTRIBUTE_NAME:
+    print_message(output, "Unexpected character (%c) in attribute name.", error->v.tokenizer.codepoint);
+    break;
+  case GUMBO_ERR_UNEXPECTED_CHARACTER_IN_UNQUOTED_ATTRIBUTE_VALUE:
+    print_message(output, "Unexpected character (%c) in unquoted attribute value.", error->v.tokenizer.codepoint);
+    break;
+  case GUMBO_ERR_UNEXPECTED_EQUALS_SIGN_BEFORE_ATTRIBUTE_NAME:
+    print_message(output, "Unexpected '=' before an attribute name.");
+    break;
+  case GUMBO_ERR_UNEXPECTED_NULL_CHARACTER:
+    print_message(output, "Input contains unexpected U+0000.");
+    break;
+  case GUMBO_ERR_UNEXPECTED_QUESTION_MARK_INSTEAD_OF_TAG_NAME:
+    print_message(output, "Unexpected '?' where start tag name is expected.");
+    break;
+  case GUMBO_ERR_UNEXPECTED_SOLIDUS_IN_TAG:
+    print_message(output, "Unexpected '/' in tag.");
+    break;
+  case GUMBO_ERR_UNKNOWN_NAMED_CHARACTER_REFERENCE:
+    print_message(output, "Unknown named character reference '%.*s'.",
+                  (int)error->original_text.length, error->original_text.data);
+    break;
+  case GUMBO_ERR_UTF8_INVALID:
+    print_message(output, "Invalid UTF8 encoding.");
+    break;
+  case GUMBO_ERR_UTF8_TRUNCATED:
+    print_message(output, "UTF8 character truncated.");
+    break;
+  case GUMBO_ERR_PARSER:
+    assert(0 && "Unreachable.");
+  }
+}
 static void handle_parser_error (
   const GumboParserError* error,
   GumboStringBuffer* output
@@ -191,127 +400,152 @@ GumboError* gumbo_add_error(GumboParser* parser) {
   return error;
 }
 
-void gumbo_error_to_string (
+GumboSourcePosition gumbo_error_position(const GumboError* error) {
+  return error->position;
+}
+
+const char* gumbo_error_code(const GumboError* error) {
+  switch (error->type) {
+  // Defined tokenizer errors.
+  case GUMBO_ERR_ABRUPT_CLOSING_OF_EMPTY_COMMENT:
+    return "abrupt-closing-of-empty-comment";
+  case GUMBO_ERR_ABRUPT_DOCTYPE_PUBLIC_IDENTIFIER:
+    return "abrupt-doctype-public-identifier";
+  case GUMBO_ERR_ABRUPT_DOCTYPE_SYSTEM_IDENTIFIER:
+    return "abrupt-doctype-system-identifier";
+  case GUMBO_ERR_ABSENCE_OF_DIGITS_IN_NUMERIC_CHARACTER_REFERENCE:
+    return "absence-of-digits-in-numeric-character-reference";
+  case GUMBO_ERR_CDATA_IN_HTML_CONTENT:
+    return "cdata-in-html-content";
+  case GUMBO_ERR_CHARACTER_REFERENCE_OUTSIDE_UNICODE_RANGE:
+    return "character-reference-outside-unicode-range";
+  case GUMBO_ERR_CONTROL_CHARACTER_IN_INPUT_STREAM:
+    return "control-character-in-input-stream";
+  case GUMBO_ERR_CONTROL_CHARACTER_REFERENCE:
+    return "control-character-reference";
+  case GUMBO_ERR_END_TAG_WITH_ATTRIBUTES:
+    return "end-tag-with-attributes";
+  case GUMBO_ERR_DUPLICATE_ATTRIBUTE:
+    return "duplicate-attribute";
+  case GUMBO_ERR_END_TAG_WITH_TRAILING_SOLIDUS:
+    return "end-tag-with-trailing-solidus";
+  case GUMBO_ERR_EOF_BEFORE_TAG_NAME:
+    return "eof-before-tag-name";
+  case GUMBO_ERR_EOF_IN_CDATA:
+    return "eof-in-cdata";
+  case GUMBO_ERR_EOF_IN_COMMENT:
+    return "eof-in-comment";
+  case GUMBO_ERR_EOF_IN_DOCTYPE:
+    return "eof-in-doctype";
+  case GUMBO_ERR_EOF_IN_SCRIPT_HTML_COMMENT_LIKE_TEXT:
+    return "eof-in-script-html-comment-like-text";
+  case GUMBO_ERR_EOF_IN_TAG:
+    return "eof-in-tag";
+  case GUMBO_ERR_INCORRECTLY_CLOSED_COMMENT:
+    return "incorrectly-closed-comment";
+  case GUMBO_ERR_INCORRECTLY_OPENED_COMMENT:
+    return "incorrectly-opened-comment";
+  case GUMBO_ERR_INVALID_CHARACTER_SEQUENCE_AFTER_DOCTYPE_NAME:
+    return "invalid-character-sequence-after-doctype-name";
+  case GUMBO_ERR_INVALID_FIRST_CHARACTER_OF_TAG_NAME:
+    return "invalid-first-character-of-tag-name";
+  case GUMBO_ERR_MISSING_ATTRIBUTE_VALUE:
+    return "missing-attribute-value";
+  case GUMBO_ERR_MISSING_DOCTYPE_NAME:
+    return "missing-doctype-name";
+  case GUMBO_ERR_MISSING_DOCTYPE_PUBLIC_IDENTIFIER:
+    return "missing-doctype-public-identifier";
+  case GUMBO_ERR_MISSING_DOCTYPE_SYSTEM_IDENTIFIER:
+    return "missing-doctype-system-identifier";
+  case GUMBO_ERR_MISSING_END_TAG_NAME:
+    return "missing-end-tag-name";
+  case GUMBO_ERR_MISSING_QUOTE_BEFORE_DOCTYPE_PUBLIC_IDENTIFIER:
+    return "missing-quote-before-doctype-public-identifier";
+  case GUMBO_ERR_MISSING_QUOTE_BEFORE_DOCTYPE_SYSTEM_IDENTIFIER:
+    return "missing-quote-before-doctype-system-identifier";
+  case GUMBO_ERR_MISSING_SEMICOLON_AFTER_CHARACTER_REFERENCE:
+    return "missing-semicolon-after-character-reference";
+  case GUMBO_ERR_MISSING_WHITESPACE_AFTER_DOCTYPE_PUBLIC_KEYWORD:
+    return "missing-whitespace-after-doctype-public-keyword";
+  case GUMBO_ERR_MISSING_WHITESPACE_AFTER_DOCTYPE_SYSTEM_KEYWORD:
+    return "missing-whitespace-after-doctype-system-keyword";
+  case GUMBO_ERR_MISSING_WHITESPACE_BEFORE_DOCTYPE_NAME:
+    return "missing-whitespace-before-doctype-name";
+  case GUMBO_ERR_MISSING_WHITESPACE_BETWEEN_ATTRIBUTES:
+    return "missing-whitespace-between-attributes";
+  case GUMBO_ERR_MISSING_WHITESPACE_BETWEEN_DOCTYPE_PUBLIC_AND_SYSTEM_IDENTIFIERS:
+    return "missing-whitespace-between-doctype-public-and-system-identifiers";
+  case GUMBO_ERR_NESTED_COMMENT:
+    return "nested-comment";
+  case GUMBO_ERR_NONCHARACTER_CHARACTER_REFERENCE:
+    return "noncharacter-character-reference";
+  case GUMBO_ERR_NONCHARACTER_IN_INPUT_STREAM:
+    return "noncharacter-in-input-stream";
+  case GUMBO_ERR_NON_VOID_HTML_ELEMENT_START_TAG_WITH_TRAILING_SOLIDUS:
+    return "non-void-html-element-start-tag-with-trailing-solidus";
+  case GUMBO_ERR_NULL_CHARACTER_REFERENCE:
+    return "null-character-reference";
+  case GUMBO_ERR_SURROGATE_CHARACTER_REFERENCE:
+    return "surrogate-character-reference";
+  case GUMBO_ERR_SURROGATE_IN_INPUT_STREAM:
+    return "surrogate-in-input-stream";
+  case GUMBO_ERR_UNEXPECTED_CHARACTER_AFTER_DOCTYPE_SYSTEM_IDENTIFIER:
+    return "unexpected-character-after-doctype-system-identifier";
+  case GUMBO_ERR_UNEXPECTED_CHARACTER_IN_ATTRIBUTE_NAME:
+    return "unexpected-character-in-attribute-name";
+  case GUMBO_ERR_UNEXPECTED_CHARACTER_IN_UNQUOTED_ATTRIBUTE_VALUE:
+    return "unexpected-character-in-unquoted-attribute-value";
+  case GUMBO_ERR_UNEXPECTED_EQUALS_SIGN_BEFORE_ATTRIBUTE_NAME:
+    return "unexpected-equals-sign-before-attribute-name";
+  case GUMBO_ERR_UNEXPECTED_NULL_CHARACTER:
+    return "unexpected-null-character";
+  case GUMBO_ERR_UNEXPECTED_QUESTION_MARK_INSTEAD_OF_TAG_NAME:
+    return "unexpected-question-mark-instead-of-tag-name";
+  case GUMBO_ERR_UNEXPECTED_SOLIDUS_IN_TAG:
+    return "unexpected-solidus-in-tag";
+  case GUMBO_ERR_UNKNOWN_NAMED_CHARACTER_REFERENCE:
+    return "unknown-named-character-reference";
+
+  // Encoding errors.
+  case GUMBO_ERR_UTF8_INVALID:
+    return "utf8-invalid";
+  case GUMBO_ERR_UTF8_TRUNCATED:
+    return "utf8-truncated";
+
+  // Generic parser error.
+  case GUMBO_ERR_PARSER:
+    return "generic-parser";
+  }
+}
+
+static void error_to_string (
   const GumboError* error,
   GumboStringBuffer* output
 ) {
-  print_message (
-    output,
-    "@%zu:%zu: ",
-    error->position.line,
-    error->position.column
-  );
-  switch (error->type) {
-    case GUMBO_ERR_UTF8_INVALID:
-      print_message (
-        output,
-        "Invalid UTF8 character 0x%" PRIx32,
-        error->v.codepoint
-      );
-      break;
-    case GUMBO_ERR_UTF8_TRUNCATED:
-      print_message (
-        output,
-        "Input stream ends with a truncated UTF8 character 0x%" PRIx32,
-        error->v.codepoint
-      );
-      break;
-    case GUMBO_ERR_UTF8_NULL:
-      print_message (
-        output,
-        "Unexpected NULL character in the input stream"
-      );
-      break;
-    case GUMBO_ERR_NUMERIC_CHAR_REF_NO_DIGITS:
-      print_message (
-        output,
-        "No digits after &# in numeric character reference"
-      );
-      break;
-    case GUMBO_ERR_NUMERIC_CHAR_REF_WITHOUT_SEMICOLON:
-      print_message (
-        output,
-        "The numeric character reference &#%" PRIu32 " should be followed "
-        "by a semicolon",
-        error->v.codepoint
-      );
-      break;
-    case GUMBO_ERR_NUMERIC_CHAR_REF_INVALID:
-      print_message (
-        output,
-        "The numeric character reference &#%" PRIu32 "; encodes an invalid "
-        "unicode codepoint",
-        error->v.codepoint
-      );
-      break;
-    case GUMBO_ERR_NAMED_CHAR_REF_WITHOUT_SEMICOLON:
-      // The textual data came from one of the literal strings in the table, and
-      // so it'll be null-terminated.
-      print_message (
-        output,
-        "The named character reference &%.*s should be followed by a "
-        "semicolon",
-        (int) error->v.text.length,
-        error->v.text.data
-      );
-      break;
-    case GUMBO_ERR_NAMED_CHAR_REF_INVALID:
-      print_message (
-        output,
-        "The named character reference &%.*s; is not a valid entity name",
-        (int) error->v.text.length,
-        error->v.text.data
-      );
-      break;
-    case GUMBO_ERR_DUPLICATE_ATTR:
-      print_message (
-        output,
-        "Attribute %s occurs multiple times, at positions %u and %u",
-        error->v.duplicate_attr.name,
-        error->v.duplicate_attr.original_index,
-        error->v.duplicate_attr.new_index
-      );
-      break;
-    case GUMBO_ERR_DASHES_OR_DOCTYPE:
-      print_message (
-        output,
-        "Incorrectly opened comment; expected '--', 'DOCTYPE', or '[CDATA['"
-      );
-      break;
-    case GUMBO_ERR_PARSER:
-      handle_parser_error(&error->v.parser, output);
-      break;
-    case GUMBO_ERR_UNACKNOWLEDGED_SELF_CLOSING_TAG:
-    case GUMBO_ERR_CLOSE_TAG_SELF_CLOSING:
-      print_message (
-        output,
-        "Tag cannot be self-closing");
-      break;
-    case GUMBO_ERR_CLOSE_TAG_HAS_ATTRIBUTES:
-      print_message (
-        output,
-        "End tag cannot have attributes");
-      break;
-    default:
-      print_message (
-        output,
-        "Tokenizer error with an unimplemented error message"
-      );
-      break;
-  }
-  gumbo_string_buffer_append_codepoint('.', output);
+  if (error->type < GUMBO_ERR_PARSER)
+    handle_tokenizer_error(error, output);
+  else
+    handle_parser_error(&error->v.parser, output);
 }
 
-void gumbo_caret_diagnostic_to_string (
+size_t gumbo_error_to_string(const GumboError* error, char** output) {
+  GumboStringBuffer sb;
+  gumbo_string_buffer_init(&sb);
+  error_to_string(error, &sb);
+  *output = sb.data;
+  return sb.length;
+}
+
+void caret_diagnostic_to_string (
   const GumboError* error,
   const char* source_text,
   size_t source_length,
   GumboStringBuffer* output
 ) {
-  gumbo_error_to_string(error, output);
+  error_to_string(error, output);
 
-  const char* line_start = find_prev_newline(source_text, error->original_text);
-  const char* line_end = find_next_newline(source_text + source_length, error->original_text);
+  const char* line_start = find_prev_newline(source_text, error->original_text.data);
+  const char* line_end = find_next_newline(source_text + source_length, error->original_text.data);
   GumboStringPiece original_line;
   original_line.data = line_start;
   original_line.length = line_end - line_start;
@@ -329,6 +563,19 @@ void gumbo_caret_diagnostic_to_string (
   gumbo_string_buffer_append_codepoint('\n', output);
 }
 
+size_t gumbo_caret_diagnostic_to_string (
+  const GumboError* error,
+  const char* source_text,
+  size_t source_length,
+  char **output
+) {
+  GumboStringBuffer sb;
+  gumbo_string_buffer_init(&sb);
+  caret_diagnostic_to_string(error, source_text, source_length, &sb);
+  *output = sb.data;
+  return sb.length;
+}
+
 void gumbo_print_caret_diagnostic (
   const GumboError* error,
   const char* source_text,
@@ -336,19 +583,21 @@ void gumbo_print_caret_diagnostic (
 ) {
   GumboStringBuffer text;
   gumbo_string_buffer_init(&text);
-  gumbo_caret_diagnostic_to_string(error, source_text, source_length, &text);
+  print_message (
+    &text,
+    "%lu:%lu: ",
+    (unsigned long)error->position.line,
+    (unsigned long)error->position.column
+  );
+
+  caret_diagnostic_to_string(error, source_text, source_length, &text);
   printf("%.*s", (int) text.length, text.data);
   gumbo_string_buffer_destroy(&text);
 }
 
 void gumbo_error_destroy(GumboError* error) {
-  if (
-    error->type == GUMBO_ERR_PARSER
-    || error->type == GUMBO_ERR_UNACKNOWLEDGED_SELF_CLOSING_TAG
-  ) {
+  if (error->type == GUMBO_ERR_PARSER) {
     gumbo_vector_destroy(&error->v.parser.tag_stack);
-  } else if (error->type == GUMBO_ERR_DUPLICATE_ATTR) {
-    gumbo_free((void*) error->v.duplicate_attr.name);
   }
   gumbo_free(error);
 }

--- a/gumbo-parser/src/error.h
+++ b/gumbo-parser/src/error.h
@@ -7,6 +7,7 @@
 #include "insertion_mode.h"
 #include "string_buffer.h"
 #include "token_type.h"
+#include "tokenizer_states.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -15,85 +16,65 @@ extern "C" {
 struct GumboInternalParser;
 
 typedef enum {
+  // Defined errors.
+  // https://html.spec.whatwg.org/multipage/parsing.html#parse-errors
+  GUMBO_ERR_ABRUPT_CLOSING_OF_EMPTY_COMMENT,
+  GUMBO_ERR_ABRUPT_DOCTYPE_PUBLIC_IDENTIFIER,
+  GUMBO_ERR_ABRUPT_DOCTYPE_SYSTEM_IDENTIFIER,
+  GUMBO_ERR_ABSENCE_OF_DIGITS_IN_NUMERIC_CHARACTER_REFERENCE,
+  GUMBO_ERR_CDATA_IN_HTML_CONTENT,
+  GUMBO_ERR_CHARACTER_REFERENCE_OUTSIDE_UNICODE_RANGE,
+  GUMBO_ERR_CONTROL_CHARACTER_IN_INPUT_STREAM,
+  GUMBO_ERR_CONTROL_CHARACTER_REFERENCE,
+  GUMBO_ERR_END_TAG_WITH_ATTRIBUTES,
+  GUMBO_ERR_DUPLICATE_ATTRIBUTE,
+  GUMBO_ERR_END_TAG_WITH_TRAILING_SOLIDUS,
+  GUMBO_ERR_EOF_BEFORE_TAG_NAME,
+  GUMBO_ERR_EOF_IN_CDATA,
+  GUMBO_ERR_EOF_IN_COMMENT,
+  GUMBO_ERR_EOF_IN_DOCTYPE,
+  GUMBO_ERR_EOF_IN_SCRIPT_HTML_COMMENT_LIKE_TEXT,
+  GUMBO_ERR_EOF_IN_TAG,
+  GUMBO_ERR_INCORRECTLY_CLOSED_COMMENT,
+  GUMBO_ERR_INCORRECTLY_OPENED_COMMENT,
+  GUMBO_ERR_INVALID_CHARACTER_SEQUENCE_AFTER_DOCTYPE_NAME,
+  GUMBO_ERR_INVALID_FIRST_CHARACTER_OF_TAG_NAME,
+  GUMBO_ERR_MISSING_ATTRIBUTE_VALUE,
+  GUMBO_ERR_MISSING_DOCTYPE_NAME,
+  GUMBO_ERR_MISSING_DOCTYPE_PUBLIC_IDENTIFIER,
+  GUMBO_ERR_MISSING_DOCTYPE_SYSTEM_IDENTIFIER,
+  GUMBO_ERR_MISSING_END_TAG_NAME,
+  GUMBO_ERR_MISSING_QUOTE_BEFORE_DOCTYPE_PUBLIC_IDENTIFIER,
+  GUMBO_ERR_MISSING_QUOTE_BEFORE_DOCTYPE_SYSTEM_IDENTIFIER,
+  GUMBO_ERR_MISSING_SEMICOLON_AFTER_CHARACTER_REFERENCE,
+  GUMBO_ERR_MISSING_WHITESPACE_AFTER_DOCTYPE_PUBLIC_KEYWORD,
+  GUMBO_ERR_MISSING_WHITESPACE_AFTER_DOCTYPE_SYSTEM_KEYWORD,
+  GUMBO_ERR_MISSING_WHITESPACE_BEFORE_DOCTYPE_NAME,
+  GUMBO_ERR_MISSING_WHITESPACE_BETWEEN_ATTRIBUTES,
+  GUMBO_ERR_MISSING_WHITESPACE_BETWEEN_DOCTYPE_PUBLIC_AND_SYSTEM_IDENTIFIERS,
+  GUMBO_ERR_NESTED_COMMENT,
+  GUMBO_ERR_NONCHARACTER_CHARACTER_REFERENCE,
+  GUMBO_ERR_NONCHARACTER_IN_INPUT_STREAM,
+  GUMBO_ERR_NON_VOID_HTML_ELEMENT_START_TAG_WITH_TRAILING_SOLIDUS,
+  GUMBO_ERR_NULL_CHARACTER_REFERENCE,
+  GUMBO_ERR_SURROGATE_CHARACTER_REFERENCE,
+  GUMBO_ERR_SURROGATE_IN_INPUT_STREAM,
+  GUMBO_ERR_UNEXPECTED_CHARACTER_AFTER_DOCTYPE_SYSTEM_IDENTIFIER,
+  GUMBO_ERR_UNEXPECTED_CHARACTER_IN_ATTRIBUTE_NAME,
+  GUMBO_ERR_UNEXPECTED_CHARACTER_IN_UNQUOTED_ATTRIBUTE_VALUE,
+  GUMBO_ERR_UNEXPECTED_EQUALS_SIGN_BEFORE_ATTRIBUTE_NAME,
+  GUMBO_ERR_UNEXPECTED_NULL_CHARACTER,
+  GUMBO_ERR_UNEXPECTED_QUESTION_MARK_INSTEAD_OF_TAG_NAME,
+  GUMBO_ERR_UNEXPECTED_SOLIDUS_IN_TAG,
+  GUMBO_ERR_UNKNOWN_NAMED_CHARACTER_REFERENCE,
+
+  // Encoding errors.
   GUMBO_ERR_UTF8_INVALID,
   GUMBO_ERR_UTF8_TRUNCATED,
-  GUMBO_ERR_UTF8_NULL,
-  GUMBO_ERR_NUMERIC_CHAR_REF_NO_DIGITS,
-  GUMBO_ERR_NUMERIC_CHAR_REF_WITHOUT_SEMICOLON,
-  GUMBO_ERR_NUMERIC_CHAR_REF_INVALID,
-  GUMBO_ERR_NAMED_CHAR_REF_WITHOUT_SEMICOLON,
-  GUMBO_ERR_NAMED_CHAR_REF_INVALID,
-  GUMBO_ERR_TAG_STARTS_WITH_QUESTION,
-  GUMBO_ERR_TAG_EOF,
-  GUMBO_ERR_TAG_INVALID,
-  GUMBO_ERR_CLOSE_TAG_EMPTY,
-  GUMBO_ERR_CLOSE_TAG_EOF,
-  GUMBO_ERR_CLOSE_TAG_INVALID,
-  GUMBO_ERR_CLOSE_TAG_SELF_CLOSING,
-  GUMBO_ERR_CLOSE_TAG_HAS_ATTRIBUTES,
-  GUMBO_ERR_SCRIPT_EOF,
-  GUMBO_ERR_ATTR_NAME_EOF,
-  GUMBO_ERR_ATTR_NAME_INVALID,
-  GUMBO_ERR_ATTR_DOUBLE_QUOTE_EOF,
-  GUMBO_ERR_ATTR_SINGLE_QUOTE_EOF,
-  GUMBO_ERR_ATTR_UNQUOTED_EOF,
-  GUMBO_ERR_ATTR_UNQUOTED_RIGHT_BRACKET,
-  GUMBO_ERR_ATTR_UNQUOTED_EQUALS,
-  GUMBO_ERR_ATTR_AFTER_EOF,
-  GUMBO_ERR_ATTR_AFTER_INVALID,
-  GUMBO_ERR_DUPLICATE_ATTR,
-  GUMBO_ERR_SOLIDUS_EOF,
-  GUMBO_ERR_SOLIDUS_INVALID,
-  GUMBO_ERR_DASHES_OR_DOCTYPE,
-  GUMBO_ERR_COMMENT_EOF,
-  GUMBO_ERR_COMMENT_INVALID,
-  GUMBO_ERR_COMMENT_BANG_AFTER_DOUBLE_DASH,
-  GUMBO_ERR_COMMENT_DASH_AFTER_DOUBLE_DASH,
-  GUMBO_ERR_COMMENT_SPACE_AFTER_DOUBLE_DASH,
-  GUMBO_ERR_COMMENT_END_BANG_EOF,
-  GUMBO_ERR_DOCTYPE_EOF,
-  GUMBO_ERR_DOCTYPE_INVALID,
-  GUMBO_ERR_DOCTYPE_SPACE,
-  GUMBO_ERR_DOCTYPE_RIGHT_BRACKET,
-  GUMBO_ERR_DOCTYPE_SPACE_OR_RIGHT_BRACKET,
-  GUMBO_ERR_DOCTYPE_END,
+
+  // Generic parser error.
   GUMBO_ERR_PARSER,
-  GUMBO_ERR_UNACKNOWLEDGED_SELF_CLOSING_TAG,
 } GumboErrorType;
-
-// Additional data for duplicated attributes.
-typedef struct GumboInternalDuplicateAttrError {
-  // The name of the attribute. Owned by this struct.
-  const char* name;
-
-  // The (0-based) index within the attributes vector of the original
-  // occurrence.
-  unsigned int original_index;
-
-  // The (0-based) index where the new occurrence would be.
-  unsigned int new_index;
-} GumboDuplicateAttrError;
-
-// A simplified representation of the tokenizer state, designed to be more
-// useful to clients of this library than the internal representation. This
-// condenses the actual states used in the tokenizer state machine into a few
-// values that will be familiar to users of HTML.
-typedef enum {
-  GUMBO_ERR_TOKENIZER_DATA,
-  GUMBO_ERR_TOKENIZER_CHAR_REF,
-  GUMBO_ERR_TOKENIZER_RCDATA,
-  GUMBO_ERR_TOKENIZER_RAWTEXT,
-  GUMBO_ERR_TOKENIZER_PLAINTEXT,
-  GUMBO_ERR_TOKENIZER_SCRIPT,
-  GUMBO_ERR_TOKENIZER_TAG,
-  GUMBO_ERR_TOKENIZER_SELF_CLOSING_TAG,
-  GUMBO_ERR_TOKENIZER_ATTR_NAME,
-  GUMBO_ERR_TOKENIZER_ATTR_VALUE,
-  GUMBO_ERR_TOKENIZER_MARKUP_DECLARATION,
-  GUMBO_ERR_TOKENIZER_COMMENT,
-  GUMBO_ERR_TOKENIZER_DOCTYPE,
-  GUMBO_ERR_TOKENIZER_CDATA,
-} GumboTokenizerErrorState;
 
 // Additional data for tokenizer errors.
 // This records the current state and codepoint encountered - this is usually
@@ -103,7 +84,7 @@ typedef struct GumboInternalTokenizerError {
   int codepoint;
 
   // The state that the tokenizer was in at the time.
-  GumboTokenizerErrorState state;
+  GumboTokenizerEnum state;
 } GumboTokenizerError;
 
 // Additional data for parse errors.
@@ -126,43 +107,25 @@ typedef struct GumboInternalParserError {
 // The overall error struct representing an error in decoding/tokenizing/parsing
 // the HTML. This contains an enumerated type flag, a source position, and then
 // a union of fields containing data specific to the error.
-typedef struct GumboInternalError {
+struct GumboInternalError {
   // The type of error.
   GumboErrorType type;
 
   // The position within the source file where the error occurred.
   GumboSourcePosition position;
 
-  // A pointer to the byte within the original source file text where the error
-  // occurred (note that this is not the same as position.offset, as that gives
-  // character-based instead of byte-based offsets).
-  const char* original_text;
+  // The piece of text that caused the error.
+  GumboStringPiece original_text;
 
   // Type-specific error information.
   union {
-    // The code point we encountered, for:
-    // * GUMBO_ERR_UTF8_INVALID
-    // * GUMBO_ERR_UTF8_TRUNCATED
-    // * GUMBO_ERR_NUMERIC_CHAR_REF_WITHOUT_SEMICOLON
-    // * GUMBO_ERR_NUMERIC_CHAR_REF_INVALID
-    uint32_t codepoint;
-
     // Tokenizer errors.
     GumboTokenizerError tokenizer;
 
-    // Short textual data, for:
-    // * GUMBO_ERR_NAMED_CHAR_REF_WITHOUT_SEMICOLON
-    // * GUMBO_ERR_NAMED_CHAR_REF_INVALID
-    GumboStringPiece text;
-
-    // Duplicate attribute data, for GUMBO_ERR_DUPLICATE_ATTR.
-    GumboDuplicateAttrError duplicate_attr;
-
-    // Parser state, for GUMBO_ERR_PARSER and
-    // GUMBO_ERR_UNACKNOWLEDGE_SELF_CLOSING_TAG.
-    struct GumboInternalParserError parser;
+    // Parser errors.
+    GumboParserError parser;
   } v;
-} GumboError;
+};
 
 // Adds a new error to the parser's error list, and returns a pointer to it so
 // that clients can fill out the rest of its fields. May return NULL if we're
@@ -177,32 +140,6 @@ void gumbo_destroy_errors(struct GumboInternalParser* errors);
 
 // Frees the memory used for a single GumboError.
 void gumbo_error_destroy(GumboError* error);
-
-// Prints an error to a string. This fills an empty GumboStringBuffer with a
-// freshly-allocated buffer containing the error message text. The caller is
-// responsible for freeing the buffer.
-void gumbo_error_to_string (
-  const GumboError* error,
-  GumboStringBuffer* output
-);
-
-// Prints a caret diagnostic to a string. This fills an empty GumboStringBuffer
-// with a freshly-allocated buffer containing the error message text. The
-// caller is responsible for freeing the buffer.
-void gumbo_caret_diagnostic_to_string (
-  const GumboError* error,
-  const char* source_text,
-  size_t source_length,
-  GumboStringBuffer* output
-);
-
-// Like gumbo_caret_diagnostic_to_string, but prints the text to stdout instead
-// of writing to a string.
-void gumbo_print_caret_diagnostic (
-  const GumboError* error,
-  const char* source_text,
-  size_t source_length
-);
 
 #ifdef __cplusplus
 }

--- a/gumbo-parser/src/gumbo.h
+++ b/gumbo-parser/src/gumbo.h
@@ -817,10 +817,6 @@ typedef struct GumboInternalOutput {
 
   /**
    * A list of errors that occurred during the parse.
-   * NOTE: In version 1.0 of this library, the API for errors hasn't been fully
-   * fleshed out and may change in the future. For this reason, the GumboError
-   * header isn't part of the public API. Contact us if you need errors
-   * reported so we can work out something appropriate for your use-case.
    */
   GumboVector /* GumboError */ errors;
 
@@ -865,6 +861,53 @@ const char* gumbo_status_to_string(GumboOutputStatus status);
 
 /** Release the memory used for the parse tree and parse errors. */
 void gumbo_destroy_output(GumboOutput* output);
+
+/** Opaque GumboError type */
+typedef struct GumboInternalError GumboError;
+
+/**
+ * Returns the position of the error.
+ */
+GumboSourcePosition gumbo_error_position(const GumboError* error);
+
+/**
+ * Returns a constant string representation of the error's code. This is owned
+ * by the library and should not be freed by the caller.
+ */
+const char* gumbo_error_code(const GumboError* error);
+
+/**
+ * Prints an error to a string. This stores a freshly-allocated buffer
+ * containing the error message text in output. The caller is responsible for
+ * freeing the buffer. The size of the error message is returned. The error
+ * message itself may not be NULL-terminated and may contain NULL bytes so the
+ * returned size must be used.
+ */
+size_t gumbo_error_to_string(const GumboError* error, char **output);
+
+/**
+ * Prints a caret diagnostic to a string. This stores a freshly-allocated
+ * buffer containing the error message text in output. The caller is responsible for
+ * freeing the buffer. The size of the error message is returned. The error
+ * message itself may not be NULL-terminated and may contain NULL bytes so the
+ * returned size must be used.
+ */
+size_t gumbo_caret_diagnostic_to_string (
+  const GumboError* error,
+  const char* source_text,
+  size_t source_length,
+  char** output
+);
+
+/**
+ * Like gumbo_caret_diagnostic_to_string, but prints the text to stdout
+ * instead of writing to a string.
+ */
+void gumbo_print_caret_diagnostic (
+  const GumboError* error,
+  const char* source_text,
+  size_t source_length
+);
 
 #ifdef __cplusplus
 }

--- a/gumbo-parser/src/token_buffer.c
+++ b/gumbo-parser/src/token_buffer.c
@@ -1,0 +1,79 @@
+/*
+ Copyright 2018 Stephen Checkoway
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+#include <assert.h>
+
+#include "ascii.h"
+#include "token_buffer.h"
+#include "tokenizer.h"
+#include "util.h"
+
+struct GumboInternalCharacterToken {
+  GumboSourcePosition position;
+  GumboStringPiece original_text;
+  int c;
+};
+
+void gumbo_character_token_buffer_init(GumboCharacterTokenBuffer* buffer) {
+  buffer->data = NULL;
+  buffer->length = 0;
+  buffer->capacity = 0;
+}
+
+void gumbo_character_token_buffer_append (
+  const GumboToken* token,
+  GumboCharacterTokenBuffer* buffer
+) {
+  assert(token->type == GUMBO_TOKEN_WHITESPACE
+         || token->type == GUMBO_TOKEN_CHARACTER);
+  if (buffer->length == buffer->capacity) {
+    if (buffer->capacity == 0)
+      buffer->capacity = 10;
+    else
+      buffer->capacity *= 2;
+    size_t bytes = sizeof(*buffer->data) * buffer->capacity;
+    buffer->data = gumbo_realloc(buffer->data, bytes);
+  }
+  size_t index = buffer->length++;
+  buffer->data[index].position = token->position;
+  buffer->data[index].original_text = token->original_text;
+  buffer->data[index].c = token->v.character;
+}
+
+void gumbo_character_token_buffer_get (
+  const GumboCharacterTokenBuffer* buffer,
+  size_t index,
+  struct GumboInternalToken* output
+) {
+  assert(index < buffer->length);
+  int c = buffer->data[index].c;
+  output->type = gumbo_ascii_isspace(c)?
+    GUMBO_TOKEN_WHITESPACE : GUMBO_TOKEN_CHARACTER;
+  output->position = buffer->data[index].position;
+  output->original_text = buffer->data[index].original_text;
+  output->v.character = c;
+}
+
+void gumbo_character_token_buffer_clear(GumboCharacterTokenBuffer* buffer) {
+  buffer->length = 0;
+}
+
+void gumbo_character_token_buffer_destroy(GumboCharacterTokenBuffer* buffer) {
+  gumbo_free(buffer->data);
+  buffer->data = NULL;
+  buffer->length = 0;
+  buffer->capacity = 0;
+}

--- a/gumbo-parser/src/token_buffer.h
+++ b/gumbo-parser/src/token_buffer.h
@@ -1,0 +1,71 @@
+/*
+ Copyright 2018 Stephen Checkoway
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+#ifndef GUMBO_TOKEN_BUFFER_H
+#define GUMBO_TOKEN_BUFFER_H
+
+#include <stdbool.h>
+#include <stddef.h>
+
+#include "gumbo.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct GumboInternalCharacterToken;
+struct GumboInternalToken;
+
+// A struct representing a growable sequence of character (and whitespace)
+// tokens.
+typedef struct {
+  // A pointer to the start of the sequence.
+  struct GumboInternalCharacterToken* data;
+
+  // The length of the sequence.
+  size_t length;
+
+  // The capacity of the buffer.
+  size_t capacity;
+} GumboCharacterTokenBuffer;
+
+// Initializes a new GumboCharacterTokenBuffer.
+void gumbo_character_token_buffer_init(GumboCharacterTokenBuffer* buffer);
+
+// Appends a character (or whitespace) token.
+void gumbo_character_token_buffer_append (
+  const struct GumboInternalToken* token,
+  GumboCharacterTokenBuffer* buffer
+);
+
+void gumbo_character_token_buffer_get (
+  const GumboCharacterTokenBuffer* buffer,
+  size_t index,
+  struct GumboInternalToken* output
+);
+
+// Reinitialize this string buffer. This clears it by setting length=0. It
+// does not zero out the buffer itself.
+void gumbo_character_token_buffer_clear(GumboCharacterTokenBuffer* buffer);
+
+// Deallocates this GumboCharacterTokenBuffer.
+void gumbo_character_token_buffer_destroy(GumboCharacterTokenBuffer* buffer);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // GUMBO_TOKEN_BUFFER_H

--- a/gumbo-parser/src/tokenizer.c
+++ b/gumbo-parser/src/tokenizer.c
@@ -1287,7 +1287,8 @@ static StateResult handle_script_data_lt_state (
   if (c == '/') {
     gumbo_tokenizer_set_state(parser, GUMBO_LEX_SCRIPT_DATA_END_TAG_OPEN);
     return CONTINUE;
-  } else if (c == '!') {
+  }
+  if (c == '!') {
     // This is the only place we don't reconsume the input before emitting the
     // temporary buffer. Since the current position is stored and the current
     // character is not emitted, we need to advance the input and then
@@ -1295,10 +1296,9 @@ static StateResult handle_script_data_lt_state (
     utf8iterator_next(&tokenizer->_input);
     reconsume_in_state(parser, GUMBO_LEX_SCRIPT_DATA_ESCAPED_START);
     return emit_from_mark(parser, output);
-  } else {
-    reconsume_in_state(parser, GUMBO_LEX_SCRIPT_DATA);
-    return emit_from_mark(parser, output);
   }
+  reconsume_in_state(parser, GUMBO_LEX_SCRIPT_DATA);
+  return emit_from_mark(parser, output);
 }
 
 // https://html.spec.whatwg.org/multipage/parsing.html#script-data-end-tag-open-state
@@ -1312,10 +1312,9 @@ static StateResult handle_script_data_end_tag_open_state (
     reconsume_in_state(parser, GUMBO_LEX_SCRIPT_DATA_END_TAG_NAME);
     start_new_tag(parser, false);
     return CONTINUE;
-  } else {
-    reconsume_in_state(parser, GUMBO_LEX_SCRIPT_DATA);
-    return emit_from_mark(parser, output);
   }
+  reconsume_in_state(parser, GUMBO_LEX_SCRIPT_DATA);
+  return emit_from_mark(parser, output);
 }
 
 // https://html.spec.whatwg.org/multipage/parsing.html#script-data-end-tag-name-state
@@ -1370,10 +1369,9 @@ static StateResult handle_script_data_escaped_start_state (
   if (c == '-') {
     gumbo_tokenizer_set_state(parser, GUMBO_LEX_SCRIPT_DATA_ESCAPED_START_DASH);
     return emit_char(parser, c, output);
-  } else {
-    reconsume_in_state(parser, GUMBO_LEX_SCRIPT_DATA);
-    return CONTINUE;
   }
+  reconsume_in_state(parser, GUMBO_LEX_SCRIPT_DATA);
+  return CONTINUE;
 }
 
 // https://html.spec.whatwg.org/multipage/parsing.html#script-data-escape-start-dash-state
@@ -1487,13 +1485,13 @@ static StateResult handle_script_data_escaped_lt_state (
   if (c == '/') {
     gumbo_tokenizer_set_state(parser, GUMBO_LEX_SCRIPT_DATA_ESCAPED_END_TAG_OPEN);
     return CONTINUE;
-  } else if (is_alpha(c)) {
+  }
+  if (is_alpha(c)) {
     reconsume_in_state(parser, GUMBO_LEX_SCRIPT_DATA_DOUBLE_ESCAPED_START);
     return emit_from_mark(parser, output);
-  } else {
-    reconsume_in_state(parser, GUMBO_LEX_SCRIPT_DATA_ESCAPED);
-    return emit_from_mark(parser, output);
   }
+  reconsume_in_state(parser, GUMBO_LEX_SCRIPT_DATA_ESCAPED);
+  return emit_from_mark(parser, output);
 }
 
 // https://html.spec.whatwg.org/multipage/parsing.html#script-data-escaped-end-tag-open-state
@@ -1507,10 +1505,9 @@ static StateResult handle_script_data_escaped_end_tag_open_state (
     reconsume_in_state(parser, GUMBO_LEX_SCRIPT_DATA_ESCAPED_END_TAG_NAME);
     start_new_tag(parser, false);
     return CONTINUE;
-  } else {
-    reconsume_in_state(parser, GUMBO_LEX_SCRIPT_DATA_ESCAPED);
-    return emit_from_mark(parser, output);
   }
+  reconsume_in_state(parser, GUMBO_LEX_SCRIPT_DATA_ESCAPED);
+  return emit_from_mark(parser, output);
 }
 
 // https://html.spec.whatwg.org/multipage/parsing.html#script-data-escaped-end-tag-name-state

--- a/gumbo-parser/src/utf8.h
+++ b/gumbo-parser/src/utf8.h
@@ -61,10 +61,6 @@ typedef struct GumboInternalUtf8Iterator {
   struct GumboInternalParser* _parser;
 } Utf8Iterator;
 
-// Returns true if this Unicode code point is in the list of characters
-// forbidden by the HTML5 spec, such as NUL bytes and undefined control chars.
-bool utf8_is_invalid_code_point(int c) CONST_FN;
-
 // Returns true if this Unicode code point is a surrogate.
 CONST_FN static inline bool utf8_is_surrogate(int c) {
   return c >= 0xD800 && c <= 0xDFFF;
@@ -96,20 +92,42 @@ void utf8iterator_init (
 void utf8iterator_next(Utf8Iterator* iter);
 
 // Returns the current code point as an integer.
-int utf8iterator_current(const Utf8Iterator* iter);
+static inline int utf8iterator_current(const Utf8Iterator* iter) {
+  return iter->_current;
+}
 
 // Retrieves and fills the output parameter with the current source position.
-void utf8iterator_get_position(
-    const Utf8Iterator* iter, GumboSourcePosition* output);
+static inline void utf8iterator_get_position (
+  const Utf8Iterator* iter,
+  GumboSourcePosition* output
+) {
+  *output = iter->_pos;
+}
+
+// Retrieves the marked position.
+static inline GumboSourcePosition utf8iterator_get_mark_position (
+  const Utf8Iterator* iter
+) {
+  return iter->_mark_pos;
+}
 
 // Retrieves a character pointer to the start of the current character.
-const char* utf8iterator_get_char_pointer(const Utf8Iterator* iter);
+static inline const char* utf8iterator_get_char_pointer(const Utf8Iterator* iter) {
+  return iter->_start;
+}
+
+// Retrieves the width of the current character.
+static inline size_t utf8iterator_get_width(const Utf8Iterator* iter) {
+  return iter->_width;
+}
 
 // Retrieves a character pointer to 1 past the end of the buffer. This is
 // necessary for certain state machines and string comparisons that would like
 // to look directly for ASCII text in the buffer without going through the
 // decoder.
-const char* utf8iterator_get_end_pointer(const Utf8Iterator* iter);
+static inline const char* utf8iterator_get_end_pointer(const Utf8Iterator* iter) {
+  return iter->_end;
+}
 
 // Retrieves a character pointer to the marked position.
 static inline const char* utf8iterator_get_mark_pointer(const Utf8Iterator* iter) {
@@ -137,13 +155,6 @@ void utf8iterator_mark(Utf8Iterator* iter);
 
 // Returns the current input stream position to the mark.
 void utf8iterator_reset(Utf8Iterator* iter);
-
-// Sets the position and original text fields of an error to the value at the
-// mark.
-void utf8iterator_fill_error_at_mark (
-  Utf8Iterator* iter,
-  struct GumboInternalError* error
-);
 
 #ifdef __cplusplus
 }

--- a/gumbo-parser/test/token_buffer.cc
+++ b/gumbo-parser/test/token_buffer.cc
@@ -1,0 +1,199 @@
+// Copyright 2018 Stephen Checkoway
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string.h>
+
+#include "token_buffer.h"
+#include "tokenizer.h"
+
+#include "gtest/gtest.h"
+#include "test_utils.h"
+#include "util.h"
+
+namespace {
+
+class GumboCharacterTokenBufferTest : public GumboTest {
+ protected:
+  GumboCharacterTokenBufferTest() {
+    gumbo_character_token_buffer_init(&buffer_);
+  }
+  virtual ~GumboCharacterTokenBufferTest() {
+    gumbo_character_token_buffer_destroy(&buffer_);
+  }
+
+  void Fill(const char* input, size_t size = -1) {
+    gumbo_character_token_buffer_clear(&buffer_);
+    if (size == -1)
+      size = strlen(input);
+    text_ = input;
+    gumbo_tokenizer_state_init(&parser_, input, size);
+
+    while (true) {
+      GumboToken token;
+      gumbo_lex(&parser_, &token);
+      if (token.type == GUMBO_TOKEN_EOF) {
+        gumbo_token_destroy(&token);
+        break;
+      }
+      ASSERT_TRUE(token.type == GUMBO_TOKEN_CHARACTER
+                  || token.type == GUMBO_TOKEN_WHITESPACE);
+      gumbo_character_token_buffer_append(&token, &buffer_);
+      gumbo_token_destroy(&token);
+    }
+  }
+
+  GumboToken Get(size_t index) {
+    GumboToken ret;
+    gumbo_character_token_buffer_get(&buffer_, index, &ret);
+    return ret;
+  }
+
+  GumboCharacterTokenBuffer buffer_;
+};
+
+TEST_F(GumboCharacterTokenBufferTest, AsciiCharacters) {
+  Fill("abcXYZ!@#$%^&*()-=_+[]{}()");
+  for (size_t i = 0; text_[i] != 0; ++i) {
+    GumboToken t = Get(i);
+    EXPECT_EQ(GUMBO_TOKEN_CHARACTER, t.type);
+    EXPECT_EQ(text_[i], t.v.character);
+    EXPECT_EQ(1, t.position.line);
+    EXPECT_EQ(i+1, t.position.column);
+    EXPECT_EQ(i, t.position.offset);
+    EXPECT_EQ(&text_[i], t.original_text.data);
+    EXPECT_EQ(1, t.original_text.length);
+  }
+}
+
+TEST_F(GumboCharacterTokenBufferTest, Whitespace) {
+  Fill("\n\f\t \r\r\n");
+  GumboToken t = Get(0);
+  EXPECT_EQ(GUMBO_TOKEN_WHITESPACE, t.type);
+  EXPECT_EQ('\n', t.v.character);
+  EXPECT_EQ(1, t.position.line);
+  EXPECT_EQ(1, t.position.column);
+  EXPECT_EQ(0, t.position.offset);
+  EXPECT_EQ(&text_[0], t.original_text.data);
+  EXPECT_EQ(1, t.original_text.length);
+
+  t = Get(1);
+  EXPECT_EQ(GUMBO_TOKEN_WHITESPACE, t.type);
+  EXPECT_EQ('\f', t.v.character);
+  EXPECT_EQ(2, t.position.line);
+  EXPECT_EQ(1, t.position.column);
+  EXPECT_EQ(1, t.position.offset);
+  EXPECT_EQ(&text_[1], t.original_text.data);
+  EXPECT_EQ(1, t.original_text.length);
+
+  t = Get(2);
+  EXPECT_EQ(GUMBO_TOKEN_WHITESPACE, t.type);
+  EXPECT_EQ('\t', t.v.character);
+  EXPECT_EQ(2, t.position.line);
+  EXPECT_EQ(2, t.position.column);
+  EXPECT_EQ(2, t.position.offset);
+  EXPECT_EQ(&text_[2], t.original_text.data);
+  EXPECT_EQ(1, t.original_text.length);
+
+  t = Get(3);
+  EXPECT_EQ(GUMBO_TOKEN_WHITESPACE, t.type);
+  EXPECT_EQ(' ', t.v.character);
+  EXPECT_EQ(2, t.position.line);
+  EXPECT_EQ(8, t.position.column);
+  EXPECT_EQ(3, t.position.offset);
+  EXPECT_EQ(&text_[3], t.original_text.data);
+  EXPECT_EQ(1, t.original_text.length);
+
+  t = Get(4);
+  EXPECT_EQ(GUMBO_TOKEN_WHITESPACE, t.type);
+  EXPECT_EQ('\n', t.v.character);
+  EXPECT_EQ(2, t.position.line);
+  EXPECT_EQ(9, t.position.column);
+  EXPECT_EQ(4, t.position.offset);
+  EXPECT_EQ(&text_[4], t.original_text.data);
+  EXPECT_EQ(1, t.original_text.length);
+
+  t = Get(5);
+  EXPECT_EQ(GUMBO_TOKEN_WHITESPACE, t.type);
+  EXPECT_EQ('\n', t.v.character);
+  EXPECT_EQ(3, t.position.line);
+  EXPECT_EQ(1, t.position.column);
+  EXPECT_EQ(6, t.position.offset);
+  EXPECT_EQ(&text_[6], t.original_text.data);
+  EXPECT_EQ(1, t.original_text.length);
+}
+
+TEST_F(GumboCharacterTokenBufferTest, Alternate) {
+  Fill("a b c");
+  for (size_t i = 0; text_[i] != 0; ++i) {
+    GumboToken t = Get(i);
+    if (i & 1)
+      EXPECT_EQ(GUMBO_TOKEN_WHITESPACE, t.type);
+    else
+      EXPECT_EQ(GUMBO_TOKEN_CHARACTER, t.type);
+    EXPECT_EQ(text_[i], t.v.character);
+    EXPECT_EQ(1, t.position.line);
+    EXPECT_EQ(i+1, t.position.column);
+    EXPECT_EQ(i, t.position.offset);
+    EXPECT_EQ(&text_[i], t.original_text.data);
+    EXPECT_EQ(1, t.original_text.length);
+  }
+}
+
+TEST_F(GumboCharacterTokenBufferTest, Entities) {
+  Fill("&vnsub;&Uuml;");
+  GumboToken t = Get(0);
+  EXPECT_EQ(GUMBO_TOKEN_CHARACTER, t.type);
+  EXPECT_EQ(0x2282, t.v.character);
+  EXPECT_EQ(1, t.position.line);
+  EXPECT_EQ(1, t.position.column);
+  EXPECT_EQ(0, t.position.offset);
+  EXPECT_EQ(&text_[0], t.original_text.data);
+  EXPECT_EQ(7, t.original_text.length);
+
+  t = Get(1);
+  EXPECT_EQ(GUMBO_TOKEN_CHARACTER, t.type);
+  EXPECT_EQ(0x20D2, t.v.character);
+  // XXX: These should probably report the same location in the source as the
+  // first token from the entity.
+  // EXPECT_EQ(1, t.position.line);
+  // EXPECT_EQ(1, t.position.column);
+  // EXPECT_EQ(0, t.position.offset);
+  // EXPECT_EQ(&text_[0], t.original_text.data);
+  // EXPECT_EQ(7, t.original_text.length);
+
+  t = Get(2);
+  EXPECT_EQ(GUMBO_TOKEN_CHARACTER, t.type);
+  EXPECT_EQ(0x00DC, t.v.character);
+  EXPECT_EQ(1, t.position.line);
+  EXPECT_EQ(8, t.position.column);
+  EXPECT_EQ(7, t.position.offset);
+  EXPECT_EQ(&text_[7], t.original_text.data);
+  EXPECT_EQ(6, t.original_text.length);
+}
+
+TEST_F(GumboCharacterTokenBufferTest, CarriageReturn) {
+  Fill("&#x0d;");
+  GumboToken t = Get(0);
+  EXPECT_EQ(GUMBO_TOKEN_WHITESPACE, t.type);
+  EXPECT_EQ(0x000D, t.v.character);
+  EXPECT_EQ(1, t.position.line);
+  EXPECT_EQ(1, t.position.column);
+  EXPECT_EQ(0, t.position.offset);
+  EXPECT_EQ(&text_[0], t.original_text.data);
+  EXPECT_EQ(6, t.original_text.length);
+}
+
+}  // namespace
+
+// vim: set sw=2 sts=2 ts=8 et:

--- a/gumbo-parser/test/tokenizer.cc
+++ b/gumbo-parser/test/tokenizer.cc
@@ -3212,6 +3212,7 @@ TEST_F(GumboTokenizerTest, Data_LT_Bang_Doctype_Space_Alpha_Space_Public_Space_A
   NextDoctype("html", NULL, NULL, true);
   Error(GUMBO_ERR_MISSING_QUOTE_BEFORE_DOCTYPE_PUBLIC_IDENTIFIER);
   EXPECT_TRUE(token_.v.doc_type.force_quirks);
+  AtEnd();
 }
 
 TEST_F(GumboTokenizerTest, Data_LT_Bang_Doctype_Space_Alpha_Space_Public_Quote) {
@@ -3248,6 +3249,7 @@ TEST_F(GumboTokenizerTest, Data_LT_Bang_Doctype_Space_Alpha_Space_Public_Anythin
   NextDoctype("html", NULL, NULL, true);
   Error(GUMBO_ERR_MISSING_QUOTE_BEFORE_DOCTYPE_PUBLIC_IDENTIFIER);
   EXPECT_TRUE(token_.v.doc_type.force_quirks);
+  AtEnd();
 }
 
 TEST_F(GumboTokenizerTest, Data_LT_Bang_Doctype_Space_Alpha_Space_System_Tab_Tab_LF_FF_Space_Quote_Quote_GT) {

--- a/gumbo-parser/test/utf8.cc
+++ b/gumbo-parser/test/utf8.cc
@@ -102,8 +102,9 @@ TEST_F(Utf8Test, ContinuationByte) {
   errors_are_expected_ = true;
   GumboError* error = GetFirstError();
   EXPECT_EQ(GUMBO_ERR_UTF8_INVALID, error->type);
-  EXPECT_EQ('\x85', *error->original_text);
-  EXPECT_EQ(0x85, error->v.codepoint);
+  EXPECT_EQ('\x85', *error->original_text.data);
+  // This isn't a valid code point so it doesn't matter what value it has.
+  // EXPECT_EQ(0x85, error->v.tokenizer.codepoint);
 
   utf8iterator_next(&input_);
   EXPECT_EQ(-1, utf8iterator_current(&input_));
@@ -133,6 +134,7 @@ TEST_F(Utf8Test, MultipleContinuationBytes) {
 
   utf8iterator_next(&input_);
   EXPECT_EQ(4, GetNumErrors());
+  errors_are_expected_ = true;
 }
 
 TEST_F(Utf8Test, OverlongEncoding) {
@@ -149,8 +151,9 @@ TEST_F(Utf8Test, OverlongEncoding) {
   EXPECT_EQ(1, error->position.line);
   EXPECT_EQ(1, error->position.column);
   EXPECT_EQ(0, error->position.offset);
-  EXPECT_EQ('\xC0', *error->original_text);
-  EXPECT_EQ(0xC0, error->v.codepoint);
+  EXPECT_EQ('\xC0', *error->original_text.data);
+  // This isn't a valid code point so it doesn't matter what value it has.
+  // EXPECT_EQ(0xC0, error->v.tokenizer.codepoint);
 
   utf8iterator_next(&input_);
   EXPECT_EQ(0x75, utf8iterator_current(&input_));
@@ -177,8 +180,9 @@ TEST_F(Utf8Test, OverlongEncodingWithContinuationByte) {
   EXPECT_EQ(1, error->position.line);
   EXPECT_EQ(1, error->position.column);
   EXPECT_EQ(0, error->position.offset);
-  EXPECT_EQ('\xC0', *error->original_text);
-  EXPECT_EQ(0xC0, error->v.codepoint);
+  EXPECT_EQ('\xC0', *error->original_text.data);
+  // This isn't a valid code point so it doesn't matter what value it has.
+  // EXPECT_EQ(0xC0, error->v.tokenizer.codepoint);
 
   utf8iterator_next(&input_);
   EXPECT_EQ(-1, utf8iterator_current(&input_));
@@ -243,6 +247,7 @@ TEST_F(Utf8Test, ThreeByteChar) {
 
   utf8iterator_next(&input_);
   EXPECT_EQ(-1, utf8iterator_current(&input_));
+  errors_are_expected_ = true;
 }
 
 TEST_F(Utf8Test, FourByteChar) {
@@ -276,6 +281,7 @@ TEST_F(Utf8Test, FourByteCharWithoutContinuationChars) {
 
   utf8iterator_next(&input_);
   EXPECT_EQ(-1, utf8iterator_current(&input_));
+  errors_are_expected_ = true;
 }
 
 TEST_F(Utf8Test, FiveByteCharIsError) {
@@ -291,6 +297,7 @@ TEST_F(Utf8Test, FiveByteCharIsError) {
   EXPECT_EQ(0xFFFD, utf8iterator_current(&input_));
   utf8iterator_next(&input_);
   EXPECT_EQ('x', utf8iterator_current(&input_));
+  errors_are_expected_ = true;
 }
 
 TEST_F(Utf8Test, SixByteCharIsError) {
@@ -307,6 +314,7 @@ TEST_F(Utf8Test, SixByteCharIsError) {
   EXPECT_EQ(0xFFFD, utf8iterator_current(&input_));
   utf8iterator_next(&input_);
   EXPECT_EQ('x', utf8iterator_current(&input_));
+  errors_are_expected_ = true;
 }
 
 TEST_F(Utf8Test, SevenByteCharIsError) {
@@ -324,6 +332,7 @@ TEST_F(Utf8Test, SevenByteCharIsError) {
   EXPECT_EQ(0xFFFD, utf8iterator_current(&input_));
   utf8iterator_next(&input_);
   EXPECT_EQ('x', utf8iterator_current(&input_));
+  errors_are_expected_ = true;
 }
 
 TEST_F(Utf8Test, 0xFFIsError) {
@@ -334,6 +343,7 @@ TEST_F(Utf8Test, 0xFFIsError) {
 
   utf8iterator_next(&input_);
   EXPECT_EQ('x', utf8iterator_current(&input_));
+  errors_are_expected_ = true;
 }
 
 TEST_F(Utf8Test, InvalidControlCharIsNotReplaced) {
@@ -344,6 +354,7 @@ TEST_F(Utf8Test, InvalidControlCharIsNotReplaced) {
 
   utf8iterator_next(&input_);
   EXPECT_EQ('x', utf8iterator_current(&input_));
+  errors_are_expected_ = true;
 }
 
 TEST_F(Utf8Test, TruncatedInput) {
@@ -358,8 +369,9 @@ TEST_F(Utf8Test, TruncatedInput) {
   EXPECT_EQ(1, error->position.line);
   EXPECT_EQ(1, error->position.column);
   EXPECT_EQ(0, error->position.offset);
-  EXPECT_EQ('\xF1', *error->original_text);
-  EXPECT_EQ(0xF1A7, error->v.codepoint);
+  EXPECT_EQ('\xF1', *error->original_text.data);
+  // This isn't a valid code point so it doesn't matter what value it has.
+  // EXPECT_EQ(0xF1A7, error->v.tokenizer.codepoint);
 
   utf8iterator_next(&input_);
   EXPECT_EQ(-1, utf8iterator_current(&input_));
@@ -369,6 +381,7 @@ TEST_F(Utf8Test, Html5SpecExample) {
   // This example has since been removed from the spec, and the spec has been
   // changed to reference the Unicode Standard 6.2, 5.22 "Best practices for
   // U+FFFD substitution."
+  errors_are_expected_ = true;
   ResetText("\x41\x98\xBA\x42\xE2\x98\x43\xE2\x98\xBA\xE2\x98");
 
   EXPECT_EQ('A', utf8iterator_current(&input_));
@@ -577,22 +590,21 @@ TEST_F(Utf8Test, MarkReset) {
   Advance(3);
   EXPECT_EQ('a', utf8iterator_current(&input_));
 
-  GumboError error;
-  utf8iterator_fill_error_at_mark(&input_, &error);
-  EXPECT_EQ('i', *error.original_text);
-  EXPECT_EQ(1, error.position.line);
-  EXPECT_EQ(6, error.position.column);
-  EXPECT_EQ(5, error.position.offset);
+  GumboSourcePosition position = utf8iterator_get_mark_position(&input_);
+  const char* original_text = utf8iterator_get_mark_pointer(&input_);
+  EXPECT_EQ('i', *original_text);
+  EXPECT_EQ(1, position.line);
+  EXPECT_EQ(6, position.column);
+  EXPECT_EQ(5, position.offset);
 
   utf8iterator_reset(&input_);
   EXPECT_EQ('i', utf8iterator_current(&input_));
   EXPECT_EQ('i', *utf8iterator_get_char_pointer(&input_));
 
-  GumboSourcePosition position;
   utf8iterator_get_position(&input_, &position);
-  EXPECT_EQ(1, error.position.line);
-  EXPECT_EQ(6, error.position.column);
-  EXPECT_EQ(5, error.position.offset);
+  EXPECT_EQ(1, position.line);
+  EXPECT_EQ(6, position.column);
+  EXPECT_EQ(5, position.offset);
 }
 
 }  // namespace


### PR DESCRIPTION
All of the standard tokenizer errors are implemented with their given
error code strings.

Each transition of the tokenizer state machine that emit one or more
errors is tested to emit exactly those errors and no others. Those
transitions that do not emit an error are tested to ensure that they do
not.

The `GumboError` is opaque to callers and the `GumboStringBuffer` is not
exposed. The error codes of the defined errors as well as the two
encoding errors and a generic parser error are available via
`gumbo_error_code`.

In Nokogiri, the error code is exposed via
`Nokogiri::XML::SyntaxError#str1`.