### PR TITLE
More precise tests for #line

### DIFF
--- a/ext/nokogumbo/nokogumbo.c
+++ b/ext/nokogumbo/nokogumbo.c
@@ -709,10 +709,12 @@ static VALUE fragment_continue(ParseArgs *args) {
 
 // Initialize the Nokogumbo class and fetch constants we will use later.
 void Init_nokogumbo() {
-  rb_funcall(rb_mKernel, rb_intern("gem"), 1, rb_utf8_str_new_static("nokogiri", 8));
+  rb_funcall(rb_mKernel, rb_intern_const("gem"), 1, rb_utf8_str_new_static("nokogiri", 8));
   rb_require("nokogiri");
 
-#ifndef NGLIB
+  VALUE line_supported = Qtrue;
+
+#if !NGLIB
   // Class constants.
   VALUE mNokogiri = rb_const_get(rb_cObject, rb_intern_const("Nokogiri"));
   VALUE mNokogiriXml = rb_const_get(mNokogiri, rb_intern_const("XML"));
@@ -725,6 +727,9 @@ void Init_nokogumbo() {
   // Interned symbols.
   new = rb_intern_const("new");
   node_name_ = rb_intern_const("node_name=");
+
+  // #line is not supported (returns 0)
+  line_supported = Qfalse;
 #endif
 
   // Class constants.
@@ -739,6 +744,11 @@ void Init_nokogumbo() {
   VALUE Gumbo = rb_define_module("Nokogumbo");
   rb_define_singleton_method(Gumbo, "parse", parse, 4);
   rb_define_singleton_method(Gumbo, "fragment", fragment, 5);
+
+  // Add private constant for testing.
+  rb_define_const(Gumbo, "LINE_SUPPORTED", line_supported);
+  rb_funcall(Gumbo, rb_intern_const("private_constant"), 1,
+             rb_utf8_str_new_cstr("LINE_SUPPORTED"));
 }
 
 // vim: set shiftwidth=2 softtabstop=2 tabstop=8 expandtab:

--- a/test/test_nokogumbo.rb
+++ b/test/test_nokogumbo.rb
@@ -223,31 +223,36 @@ class TestNokogumbo < Minitest::Test
   end
 
   def test_line_text
+    skip unless Nokogumbo.const_get(:LINE_SUPPORTED)
     doc = Nokogiri.HTML5("<!DOCTYPE html>\ntext node")
-    assert_includes [0, 2], doc.at_xpath('/html/body/text()').line
+    assert_equal 2, doc.at_xpath('/html/body/text()').line
   end
 
   def test_line_comment
+    skip unless Nokogumbo.const_get(:LINE_SUPPORTED)
     doc = Nokogiri.HTML5("<!DOCTYPE html>\n\n<!-- comment -->")
-    assert_includes [0, 3], doc.at_xpath('/comment()').line
+    assert_equal 3, doc.at_xpath('/comment()').line
   end
 
   def test_line_element
+    skip unless Nokogumbo.const_get(:LINE_SUPPORTED)
     doc = Nokogiri.HTML5("<!DOCTYPE html>\n<p>")
-    assert_includes [0, 2], doc.at_xpath('/html/body/p').line
+    assert_equal 2, doc.at_xpath('/html/body/p').line
   end
 
   def test_line_template
+    skip unless Nokogumbo.const_get(:LINE_SUPPORTED)
     doc = Nokogiri.HTML5("<!DOCTYPE html>\n\n<template></template>")
-    assert_includes [0, 3], doc.at_xpath('/html/head/template').line
+    assert_equal 3, doc.at_xpath('/html/head/template').line
   end
 
   def test_line_cdata
+    skip unless Nokogumbo.const_get(:LINE_SUPPORTED)
     html = "<!DOCTYPE html>\n<svg>\n<script><![CDATA[ ]]></script></svg>"
     doc = Nokogiri.HTML5(html)
     node = doc.at_xpath('/html/body/svg:svg/svg:script/text()')
     assert node.cdata?
-    assert_includes [0, 3], node.line
+    assert_equal 3, node.line
   end
 
 private


### PR DESCRIPTION
Use a private constant to enable precise tests of `#line`.