### PR TITLE
Fix travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,11 @@ matrix:
       rvm: 2.5
       script: scripts/ci-package-test.sh
 
+before_install: |
+  if ruby -e 'exit(Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.3"))'; then
+    gem uninstall --version '>= 2' -i "$(rvm gemdir)@global" -ax bundler || true
+    gem install bundler --version '< 2'
+  fi
 #install: git clone --depth 1 --branch master --single-branch https://github.com/html5lib/html5lib-tests.git test/html5lib-tests
 install: git clone --depth 1 --branch all-error-fixes --single-branch https://github.com/stevecheckoway/html5lib-tests.git test/html5lib-tests
 script: scripts/ci-test.sh


### PR DESCRIPTION
The latest version of bundler (version 2) doesn't work with Ruby
versions before 2.3. Travis fails to install the appropriate version of
bundler for older versions of Ruby, but seemingly only on macOS. Travis
support suggested adding the following to `.travis.yml`.

``` yaml
before_install:
  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
  - gem install bundler -v '< 2'
```

This change performs that action, but only if `RUBY_VERSION` is less
than 2.3.