### PR TITLE
Fix build on Linux with Ruby 2.1

### DIFF
--- a/ext/nokogumbo/nokogumbo.c
+++ b/ext/nokogumbo/nokogumbo.c
@@ -33,6 +33,7 @@ static ID parent;
 
 /* Backwards compatibility to Ruby 2.1.0 */
 #if RUBY_API_VERSION_CODE < 20200
+#define ONIG_ESCAPE_UCHAR_COLLISION 1
 #include <ruby/encoding.h>
 
 static VALUE rb_utf8_str_new(const char *str, long length) {


### PR DESCRIPTION
There appears to be a conflict with a definition of `UChar` conflicting
with Ruby's. We can avoid this by defining
`ONIG_ESCAPE_UCHAR_COLLISION`.