### PR TITLE
Error handling

### DIFF
--- a/gumbo-parser/src/error.c
+++ b/gumbo-parser/src/error.c
@@ -391,6 +391,8 @@ static const char* find_next_newline(
 }
 
 GumboError* gumbo_add_error(GumboParser* parser) {
+  parser->_output->document_error = true;
+
   int max_errors = parser->_options->max_errors;
   if (max_errors >= 0 && parser->_output->errors.length >= (unsigned int) max_errors) {
     return NULL;

--- a/gumbo-parser/src/gumbo.h
+++ b/gumbo-parser/src/gumbo.h
@@ -821,6 +821,14 @@ typedef struct GumboInternalOutput {
   GumboVector /* GumboError */ errors;
 
   /**
+   * True if the parser encounted an error.
+   *
+   * This can be true and `errors` an empty `GumboVector` if the `max_errors`
+   * option was set to 0.
+   */
+  bool document_error;
+
+  /**
    * A status code indicating whether parsing finished successfully or was
    * stopped mid-document due to exceptional circumstances.
    */

--- a/gumbo-parser/src/tokenizer.h
+++ b/gumbo-parser/src/tokenizer.h
@@ -93,19 +93,8 @@ void gumbo_tokenizer_set_is_adjusted_current_node_foreign (
 );
 
 // Lexes a single token from the specified buffer, filling the output with the
-// parsed GumboToken data structure. Returns true for a successful
-// tokenization, false if a parse error occurs.
-//
-// Example:
-//   struct GumboInternalParser parser;
-//   GumboToken output;
-//   gumbo_tokenizer_state_init(&parser, text, strlen(text));
-//   while (gumbo_lex(&parser, &output)) {
-//     ...do stuff with output.
-//     gumbo_token_destroy(&token);
-//   }
-//   gumbo_tokenizer_state_destroy(&parser);
-bool gumbo_lex(struct GumboInternalParser* parser, GumboToken* output);
+// parsed GumboToken data structure.
+void gumbo_lex(struct GumboInternalParser* parser, GumboToken* output);
 
 // Frees the internally-allocated pointers within a GumboToken. Note that this
 // doesn't free the token itself, since oftentimes it will be allocated on the

--- a/gumbo-parser/test/tokenizer.cc
+++ b/gumbo-parser/test/tokenizer.cc
@@ -71,12 +71,11 @@ class GumboTokenizerTest : public GumboTest {
     if (!at_start_)
       gumbo_token_destroy(&token_);
     at_start_ = false;
-    if (errors_are_expected) {
-      errors_are_expected_ = true;
-      EXPECT_FALSE(gumbo_lex(&parser_, &token_));
-    } else {
-      EXPECT_TRUE(gumbo_lex(&parser_, &token_));
-    }
+    // Reset the document errors.
+    parser_._output->document_error = false;
+    gumbo_lex(&parser_, &token_);
+    EXPECT_EQ(errors_are_expected, parser_._output->document_error);
+    errors_are_expected_ = errors_are_expected;
   }
 
   void NextChar(int c, bool errors_are_expected = false) {


### PR DESCRIPTION
The parser and a bit of the tokenizer returned `false` if there was a parse error. This code was not well tested and definitely had errors. Since all errors go through a single `gumbo_add_error` function, that can set a member of the `GumboOutput` to indicate if there are any errors.

This is only used to stop parsing on the first error, although we could expose it to ruby for clients who wish to know if there was a parsing error but don't care what the error is.