### PR TITLE
Use Nokogiri with line numbers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ source 'https://rubygems.org'
 # alphabetical order so it tries to install Nokogiri before pkg-config and
 # this fails.
 gem 'fix-dep-order', :path => 'scripts'
-gem 'nokogiri', '>= 1.8'
+gem 'nokogiri', :git => 'git@github.com:stevecheckoway/nokogiri.git', :tag => 'linenum'
 
 group :development, :test do
   gem 'minitest'


### PR DESCRIPTION
This allows to use the PR at https://github.com/sparklemotion/nokogiri/pull/1918 today.

Then development effort can continue using line numbers. This is a path forward to allow html-proofer to work with HTML5.

Recommending that this PR be updated to merge into a new branch here, rather than master.