### PR TITLE
Skip the unicode byte order mark

### DIFF
--- a/gumbo-parser/src/utf8.c
+++ b/gumbo-parser/src/utf8.c
@@ -193,6 +193,11 @@ void utf8iterator_init (
   iter->_pos.offset = 0;
   iter->_parser = parser;
   read_char(iter);
+  if (iter->_current == kUtf8BomChar) {
+    iter->_start += iter->_width;
+    iter->_pos.offset += iter->_width;
+    read_char(iter);
+  }
 }
 
 void utf8iterator_next(Utf8Iterator* iter) {

--- a/gumbo-parser/src/utf8.h
+++ b/gumbo-parser/src/utf8.h
@@ -31,6 +31,7 @@ struct GumboInternalParser;
 
 // Unicode replacement char.
 #define kUtf8ReplacementChar 0xFFFD
+#define kUtf8BomChar 0xFEFF
 #define kUtf8MaxChar 0x10FFFF
 
 typedef struct GumboInternalUtf8Iterator {

--- a/gumbo-parser/test/utf8.cc
+++ b/gumbo-parser/test/utf8.cc
@@ -509,6 +509,19 @@ TEST_F(Utf8Test, CRLF) {
   EXPECT_EQ(8, pos.offset);
 }
 
+TEST_F(Utf8Test, SkipBom) {
+  ResetText("\xEF\xBB\xBFX");
+
+  EXPECT_EQ(0, GetNumErrors());
+  EXPECT_EQ('X', utf8iterator_current(&input_));
+
+  GumboSourcePosition pos;
+  utf8iterator_get_position(&input_, &pos);
+  EXPECT_EQ(1, pos.line);
+  EXPECT_EQ(1, pos.column);
+  EXPECT_EQ(3, pos.offset);
+}
+
 TEST_F(Utf8Test, CarriageReturn) {
   ResetText("Mac\rlinefeeds");
   Advance(sizeof("Mac") - 1);

--- a/test/test_encoding.rb
+++ b/test/test_encoding.rb
@@ -28,6 +28,24 @@ class TestNokogumbo < Minitest::Test
       doc = Nokogiri::HTML5(bogus)
       assert_equal '<span>Señor</span>', doc.at('span').to_xml
     end
+
+    def test_utf8_bom
+      utf8 = "\uFEFF<!DOCTYPE html><html></html>".encode('UTF-8')
+      doc = Nokogiri::HTML5(utf8, max_errors: 10)
+      assert_equal [], doc.errors
+    end
+
+    def test_utf16le_bom
+      utf16le = "\uFEFF<!DOCTYPE html><html></html>".encode('UTF-16LE')
+      doc = Nokogiri::HTML5(utf16le, max_errors: 10)
+      assert_equal [], doc.errors
+    end
+
+    def test_utf16be_bom
+      utf16be = "\uFEFF<!DOCTYPE html><html></html>".encode('UTF-16BE')
+      doc = Nokogiri::HTML5(utf16be, max_errors: 10)
+      assert_equal [], doc.errors
+    end
   end
 
   # https://github.com/rubys/nokogumbo/issues/68


### PR DESCRIPTION
UTF-8 doesn't need a byte order mark (BOM), but UTF-16LE and UTF-16BE
frequently use one and `string#encode` preserves it when converting to
UTF-8.

```
irb(main):049:0> "\uFEFFXXX".encode(Encoding::UTF_16LE).bytes
=> [255, 254, 88, 0, 88, 0, 88, 0]
irb(main):050:0> "\uFEFFXXX".encode(Encoding::UTF_16LE).encode(Encoding::UTF_8).bytes
=> [239, 187, 191, 88, 88, 88]
```

Fixes: #133