### PR TITLE
Fix content-sniffing for Unicode strings

### DIFF
--- a/lib/nokogumbo/html5/document.rb
+++ b/lib/nokogumbo/html5/document.rb
@@ -12,6 +12,9 @@ module Nokogiri
         if string_or_io.respond_to?(:read) && string_or_io.respond_to?(:path)
           url ||= string_or_io.path
         end
+        unless string_or_io.respond_to?(:read) || string_or_io.respond_to?(:to_str)
+          raise ArgumentError.new("not a string or IO object")
+        end
         do_parse(string_or_io, url, encoding, options)
       end
 
@@ -21,7 +24,8 @@ module Nokogiri
       end
 
       def self.read_memory(string, url = nil, encoding = nil, **options)
-        do_parse(string.to_s, url, encoding, options)
+        raise ArgumentError.new("string object doesn't respond to :to_str") unless string.respond_to?(:to_str)
+        do_parse(string, url, encoding, options)
       end
 
       def fragment(tags = nil)
@@ -39,7 +43,7 @@ module Nokogiri
         string = HTML5.read_and_encode(string_or_io, encoding)
         max_errors = options[:max_errors] || options[:max_parse_errors] || Nokogumbo::DEFAULT_MAX_ERRORS
         max_depth = options[:max_tree_depth] || Nokogumbo::DEFAULT_MAX_TREE_DEPTH
-        doc = Nokogumbo.parse(string.to_s, url, max_errors, max_depth)
+        doc = Nokogumbo.parse(string, url, max_errors, max_depth)
         doc.encoding = 'UTF-8'
         doc
       end

--- a/test/test_api.rb
+++ b/test/test_api.rb
@@ -105,22 +105,45 @@ class TestAPI < Minitest::Test
     end
   end
 
-  def test_document_io_failure
-    html = '<!DOCTYPE html><span>test</span>'
-    assert_raises(ArgumentError) { Nokogiri::HTML5::Document.read_io(html) }
-  end
-
   def test_document_io
     html = StringIO.new('<!DOCTYPE html><span>test</span>', 'r')
     doc = Nokogiri::HTML5::Document.read_io(html)
     refute_nil doc.at_xpath('/html/body/span')
   end
 
-  def test_document_memor
+  def test_document_memory
     html = '<!DOCTYPE html><span>test</span>'
     doc = Nokogiri::HTML5::Document.read_memory(html)
     refute_nil doc
     refute_nil doc.at_xpath('/html/body/span')
+  end
+
+  def test_document_io_failure
+    html = '<!DOCTYPE html><span>test</span>'
+    assert_raises(ArgumentError) { Nokogiri::HTML5::Document.read_io(html) }
+  end
+
+  def test_document_memory_failure
+    html = StringIO.new('<!DOCTYPE html><span>test</span>', 'r')
+    assert_raises(ArgumentError) { Nokogiri::HTML5::Document.read_memory(html) }
+  end
+
+  def test_document_parse_failure
+    html = ['Neither a string, nor I/O']
+    assert_raises(ArgumentError) { Nokogiri::HTML5::Document.parse(html) }
+  end
+
+  def test_ownership
+    # Test that we don't change the passed in string, even if we need to
+    # re-encode it.
+    html = '<!DOCTYPE html><html></html>'.freeze
+    refute_nil Nokogiri::HTML5.parse(html)
+
+    iso8859_1 = html.encode(Encoding::ISO_8859_1).freeze
+    refute_nil Nokogiri::HTML5.parse(iso8859_1)
+
+    ascii_8bit = html.encode(Encoding::ASCII_8BIT).freeze
+    refute_nil Nokogiri::HTML5.parse(ascii_8bit)
   end
 
   def test_fragment_from_node

--- a/test/test_encoding.rb
+++ b/test/test_encoding.rb
@@ -46,6 +46,30 @@ class TestNokogumbo < Minitest::Test
       doc = Nokogiri::HTML5(utf16be, max_errors: 10)
       assert_equal [], doc.errors
     end
+
+    def test_utf8_bom_ascii
+      utf8 = "\uFEFF<!DOCTYPE html><html></html>".encode('UTF-8')
+      utf8.force_encoding(Encoding::ASCII_8BIT)
+      doc = Nokogiri::HTML5(utf8, max_errors: 10)
+      doc.errors.each { |err| puts(err) }
+      assert_equal [], doc.errors
+    end
+
+    def test_utf16le_bom_ascii
+      utf16le = "\uFEFF<!DOCTYPE html><html></html>".encode('UTF-16LE')
+      utf16le.force_encoding(Encoding::ASCII_8BIT)
+      doc = Nokogiri::HTML5(utf16le, max_errors: 10)
+      assert_equal [], doc.errors
+      doc.errors.each { |err| puts(err) }
+    end
+
+    def test_utf16be_bom_ascii
+      utf16be = "\uFEFF<!DOCTYPE html><html></html>".encode('UTF-16BE')
+      utf16be.force_encoding(Encoding::ASCII_8BIT)
+      doc = Nokogiri::HTML5(utf16be, max_errors: 10)
+      assert_equal [], doc.errors
+      doc.errors.each { |err| puts(err) }
+    end
   end
 
   # https://github.com/rubys/nokogumbo/issues/68


### PR DESCRIPTION
"\xEF\xBB\xBF" is a valid UTF-8 string of length 1. It will never
compare equal to the first three bytes of the input.

```
irb(main):058:0> "\xEF\xBB\xBF".force_encoding(Encoding::ASCII_8BIT) == "\xEF\xBB\xBF"
=> false
```

Instead, use `string#bytes` to examine the first few bytes of the
input to decide if the unicode BOM is present and to set the encoding
appropriately.

Additionally test that we're not modifying any strings that the user has
passed to us since we're using `string#force_encoding` in a few places.