### PR TITLE
Fix travis-ci build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,13 +27,20 @@ matrix:
     - name: Test Gumbo and gem packaging
       os: linux
       language: ruby
-      rvm: 2.5
+      rvm: 2.7
       script: scripts/ci-package-test.sh
     - name: Test Gumbo and gem packaging
       os: osx
       language: ruby
-      rvm: 2.6
+      rvm: 2.7
       script: scripts/ci-package-test.sh
+  exclude:
+    - rvm: 2.1
+      os: osx
+    - rvm: 2.2
+      os: osx
+    - rvm: 2.3
+      os: osx
 
 before_install: |
   if ruby -e 'exit(Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.3"))'; then


### PR DESCRIPTION
Travis CI does not currently work for Ruby 2.1 through 2.3 on macOS. See
https://travis-ci.community/t/missing-libraries-for-ruby-2-1-2-2-and-2-3-on-macos/6792

This excludes these builds from the build matrix and also updates the
packing testing to 2.7.