### PR TITLE
Increment Ruby versions.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,14 +6,14 @@ cache:
 environment:
   NO_GUMBO_TESTS: true
   matrix:
-    - RUBY_VERSION: 23
-    - RUBY_VERSION: 23-x64
     - RUBY_VERSION: 24
     - RUBY_VERSION: 24-x64
     - RUBY_VERSION: 25
     - RUBY_VERSION: 25-x64
     - RUBY_VERSION: 26
     - RUBY_VERSION: 26-x64
+    - RUBY_VERSION: 27
+    - RUBY_VERSION: 27-x64
 
 install:
   - set PATH=C:\Ruby%RUBY_VERSION%\bin;C:\msys64\usr\bin;%PATH%


### PR DESCRIPTION
Test Ruby 2.7 and drop support for Ruby 2.3. 2.3 EOL'd already and
Appveyor is very slow so let's not bother testing.

[skip travis]