### PR TITLE
Limit number of attributes per element to prevent DoS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
+- Limit enforced on number of attributes per element, defaulting to 400 and
+  configurable with the `:max_attributes` argument.
+
 ### Changed
 ### Deprecated
 ### Removed

--- a/README.md
+++ b/README.md
@@ -128,6 +128,22 @@ doc = Nokogiri.HTML5(html)
 doc = Nokogiri.HTML5(html, max_tree_depth: -1)
 ```
 
+### Attribute limit per element
+The maximum number of attributes per DOM element is configurable by the
+`:max_attributes` option. If a given element would exceed this limit, then an
+[ArgumentError](https://ruby-doc.org/core-2.5.0/ArgumentError.html) is thrown.
+
+This limit (which defaults to `Nokogumbo::DEFAULT_MAX_ATTRIBUTES = 400`) can
+be removed by giving the option `max_attributes: -1`.
+
+``` ruby
+html = '<!DOCTYPE html><div ' + (1..1000).map { |x| "attr-#{x}" }.join(' ') + '>'
+# "<!DOCTYPE html><div attr-1 attr-2 attr-3 ... attr-1000>"
+doc = Nokogiri.HTML5(html)
+# raises ArgumentError: Attributes per element limit exceeded
+doc = Nokogiri.HTML5(html, max_attributes: -1)
+```
+
 ## HTML Serialization
 
 After parsing HTML, it may be serialized using any of the Nokogiri

--- a/ext/nokogumbo/nokogumbo.c
+++ b/ext/nokogumbo/nokogumbo.c
@@ -281,6 +281,7 @@ static GumboOutput *perform_parse(const GumboOptions *options, VALUE input) {
   switch (output->status) {
   case GUMBO_STATUS_OK:
     break;
+  case GUMBO_STATUS_TOO_MANY_ATTRIBUTES:
   case GUMBO_STATUS_TREE_TOO_DEEP:
     gumbo_destroy_output(output);
     rb_raise(rb_eArgError, "%s", status_string);

--- a/ext/nokogumbo/nokogumbo.c
+++ b/ext/nokogumbo/nokogumbo.c
@@ -490,8 +490,9 @@ static VALUE parse_cleanup(ParseArgs *args) {
 static VALUE parse_continue(ParseArgs *args);
 
 // Parse a string using gumbo_parse into a Nokogiri document
-static VALUE parse(VALUE self, VALUE input, VALUE url, VALUE max_errors, VALUE max_depth) {
+static VALUE parse(VALUE self, VALUE input, VALUE url, VALUE max_attributes, VALUE max_errors, VALUE max_depth) {
   GumboOptions options = kGumboDefaultOptions;
+  options.max_attributes = NUM2INT(max_attributes);
   options.max_errors = NUM2INT(max_errors);
   options.max_tree_depth = NUM2INT(max_depth);
 
@@ -570,6 +571,7 @@ static VALUE fragment (
   VALUE doc_fragment,
   VALUE tags,
   VALUE ctx,
+  VALUE max_attributes,
   VALUE max_errors,
   VALUE max_depth
 ) {
@@ -676,6 +678,7 @@ static VALUE fragment (
   // Perform a fragment parse.
   int depth = NUM2INT(max_depth);
   GumboOptions options = kGumboDefaultOptions;
+  options.max_attributes = NUM2INT(max_attributes);
   options.max_errors = NUM2INT(max_errors);
   // Add one to account for the HTML element.
   options.max_tree_depth = depth < 0 ? -1 : (depth + 1);
@@ -743,8 +746,8 @@ void Init_nokogumbo() {
 
   // Define Nokogumbo module with parse and fragment methods.
   VALUE Gumbo = rb_define_module("Nokogumbo");
-  rb_define_singleton_method(Gumbo, "parse", parse, 4);
-  rb_define_singleton_method(Gumbo, "fragment", fragment, 5);
+  rb_define_singleton_method(Gumbo, "parse", parse, 5);
+  rb_define_singleton_method(Gumbo, "fragment", fragment, 6);
 
   // Add private constant for testing.
   rb_define_const(Gumbo, "LINE_SUPPORTED", line_supported);

--- a/gumbo-parser/src/gumbo.h
+++ b/gumbo-parser/src/gumbo.h
@@ -708,8 +708,9 @@ typedef struct GumboInternalOptions {
 
   /**
    * Maximum allowed number of attributes per element. If this limit is
-   * reached, the parser will start ignoring attributes until the end of
-   * the current opening tag. Set to `-1` to disable the limit.
+   * exceeded, the parser will return early with a partial document and
+   * the returned `GumboOutput` will have its `status` field set to
+   * `GUMBO_STATUS_TOO_MANY_ATTRIBUTES`. Set to `-1` to disable the limit.
    * Default: `400`.
    */
   int max_attributes;
@@ -803,6 +804,16 @@ typedef enum {
    * typically shouldn't be used for other purposes.
    */
   GUMBO_STATUS_TREE_TOO_DEEP,
+
+  /**
+   * Indicates that the maximum number of attributes per element
+   * (`GumboOptions::max_attributes`) was reached during parsing. The
+   * resulting tree will be a partial document, with no further nodes
+   * created after the point where the limit was reached. The partial
+   * document may be useful for constructing an error message but
+   * typically shouldn't be used for other purposes.
+   */
+  GUMBO_STATUS_TOO_MANY_ATTRIBUTES,
 
   // Currently unused
   GUMBO_STATUS_OUT_OF_MEMORY,

--- a/gumbo-parser/src/gumbo.h
+++ b/gumbo-parser/src/gumbo.h
@@ -707,6 +707,14 @@ typedef struct GumboInternalOptions {
   bool stop_on_first_error;
 
   /**
+   * Maximum allowed number of attributes per element. If this limit is
+   * reached, the parser will start ignoring attributes until the end of
+   * the current opening tag. Set to `-1` to disable the limit.
+   * Default: `400`.
+   */
+  int max_attributes;
+
+  /**
    * Maximum allowed depth for the parse tree. If this limit is exceeded,
    * the parser will return early with a partial document and the returned
    * `GumboOutput` will have its `status` field set to

--- a/gumbo-parser/src/parser.c
+++ b/gumbo-parser/src/parser.c
@@ -48,6 +48,7 @@ typedef uint8_t TagSet[GUMBO_TAG_LAST + 1];
 const GumboOptions kGumboDefaultOptions = {
   .tab_stop = 8,
   .stop_on_first_error = false,
+  .max_attributes = 400,
   .max_tree_depth = 400,
   .max_errors = -1,
   .fragment_context = NULL,

--- a/gumbo-parser/src/parser.c
+++ b/gumbo-parser/src/parser.c
@@ -4859,6 +4859,8 @@ const char* gumbo_status_to_string(GumboOutputStatus status) {
       return "OK";
     case GUMBO_STATUS_OUT_OF_MEMORY:
       return "System allocator returned NULL during parsing";
+    case GUMBO_STATUS_TOO_MANY_ATTRIBUTES:
+      return "Attributes per element limit exceeded";
     case GUMBO_STATUS_TREE_TOO_DEEP:
       return "Document tree depth limit exceeded";
     default:

--- a/gumbo-parser/src/tokenizer.c
+++ b/gumbo-parser/src/tokenizer.c
@@ -784,12 +784,20 @@ static void add_duplicate_attr_error(GumboParser* parser) {
 static void finish_attribute_name(GumboParser* parser) {
   GumboTokenizerState* tokenizer = parser->_tokenizer_state;
   GumboTagState* tag_state = &tokenizer->_tag_state;
+  GumboVector* /* GumboAttribute* */ attributes = &tag_state->_attributes;
+
+  int max_attributes = parser->_options->max_attributes;
+  if (max_attributes >= 0 && attributes->length >= (unsigned int) max_attributes) {
+    reinitialize_tag_buffer(parser);
+    tag_state->_drop_next_attr_value = true;
+    return;
+  }
+
   // May've been set by a previous attribute without a value; reset it here.
   tag_state->_drop_next_attr_value = false;
   assert(tag_state->_attributes.data);
   assert(tag_state->_attributes.capacity);
 
-  GumboVector* /* GumboAttribute* */ attributes = &tag_state->_attributes;
   for (unsigned int i = 0; i < attributes->length; ++i) {
     GumboAttribute* attr = attributes->data[i];
     if (

--- a/gumbo-parser/src/tokenizer.c
+++ b/gumbo-parser/src/tokenizer.c
@@ -787,7 +787,9 @@ static void finish_attribute_name(GumboParser* parser) {
   GumboVector* /* GumboAttribute* */ attributes = &tag_state->_attributes;
 
   int max_attributes = parser->_options->max_attributes;
-  if (max_attributes >= 0 && attributes->length >= (unsigned int) max_attributes) {
+  if (unlikely(max_attributes >= 0 && attributes->length >= (unsigned int) max_attributes)) {
+    parser->_output->status = GUMBO_STATUS_TOO_MANY_ATTRIBUTES;
+    gumbo_debug("Attributes limit exceeded.\n");
     reinitialize_tag_buffer(parser);
     tag_state->_drop_next_attr_value = true;
     return;

--- a/lib/nokogumbo.rb
+++ b/lib/nokogumbo.rb
@@ -5,6 +5,9 @@ require 'nokogumbo/html5'
 require 'nokogumbo/nokogumbo'
 
 module Nokogumbo
+  # The default maximum number of attributes per element.
+  DEFAULT_MAX_ATTRIBUTES = 400
+
   # The default maximum number of errors for parsing a document or a fragment.
   DEFAULT_MAX_ERRORS = 0
 

--- a/lib/nokogumbo/html5/document.rb
+++ b/lib/nokogumbo/html5/document.rb
@@ -41,9 +41,10 @@ module Nokogiri
       private
       def self.do_parse(string_or_io, url, encoding, options)
         string = HTML5.read_and_encode(string_or_io, encoding)
+        max_attributes = options[:max_attributes] || Nokogumbo::DEFAULT_MAX_ATTRIBUTES
         max_errors = options[:max_errors] || options[:max_parse_errors] || Nokogumbo::DEFAULT_MAX_ERRORS
         max_depth = options[:max_tree_depth] || Nokogumbo::DEFAULT_MAX_TREE_DEPTH
-        doc = Nokogumbo.parse(string, url, max_errors, max_depth)
+        doc = Nokogumbo.parse(string, url, max_attributes, max_errors, max_depth)
         doc.encoding = 'UTF-8'
         doc
       end

--- a/lib/nokogumbo/html5/document_fragment.rb
+++ b/lib/nokogumbo/html5/document_fragment.rb
@@ -12,10 +12,11 @@ module Nokogiri
         self.errors = []
         return self unless tags
 
+        max_attributes = options[:max_attributes] || Nokogumbo::DEFAULT_MAX_ATTRIBUTES
         max_errors = options[:max_errors] || Nokogumbo::DEFAULT_MAX_ERRORS
         max_depth = options[:max_tree_depth] || Nokogumbo::DEFAULT_MAX_TREE_DEPTH
         tags = Nokogiri::HTML5.read_and_encode(tags, nil)
-        Nokogumbo.fragment(self, tags, ctx, max_errors, max_depth)
+        Nokogumbo.fragment(self, tags, ctx, max_attributes, max_errors, max_depth)
       end
 
       def serialize(options = {}, &block)

--- a/test/test_nokogumbo.rb
+++ b/test/test_nokogumbo.rb
@@ -123,9 +123,9 @@ class TestNokogumbo < Minitest::Test
   def test_max_attributes
     html = '<div id="i" class="c" title="t"><img src="s" alt="a"></div>'
 
-    assert_raises(ArgumentError ) { Nokogiri::HTML5(html, max_attributes: 2) }
-    assert_raises(ArgumentError ) { Nokogiri::HTML5(html, max_attributes: 1) }
-    assert_raises(ArgumentError ) { Nokogiri::HTML5(html, max_attributes: 0) }
+    assert_raises(ArgumentError) { Nokogiri::HTML5(html, max_attributes: 2) }
+    assert_raises(ArgumentError) { Nokogiri::HTML5(html, max_attributes: 1) }
+    assert_raises(ArgumentError) { Nokogiri::HTML5(html, max_attributes: 0) }
 
     # -1 disables limit
     doc = Nokogiri::HTML5(html, max_attributes: -1)
@@ -139,10 +139,10 @@ class TestNokogumbo < Minitest::Test
     doc = Nokogiri::HTML5(html, max_attributes: 4)
     assert_equal({ 'checked' => '', 'type' => 'checkbox', 'disabled' => '', 'name' => 'cheese' }, attributes(doc.at_css('input')))
 
-    assert_raises(ArgumentError ) { Nokogiri::HTML5(html, max_attributes: 3) }
-    assert_raises(ArgumentError ) { Nokogiri::HTML5(html, max_attributes: 2) }
-    assert_raises(ArgumentError ) { Nokogiri::HTML5(html, max_attributes: 1) }
-    assert_raises(ArgumentError ) { Nokogiri::HTML5(html, max_attributes: 0) }
+    assert_raises(ArgumentError) { Nokogiri::HTML5(html, max_attributes: 3) }
+    assert_raises(ArgumentError) { Nokogiri::HTML5(html, max_attributes: 2) }
+    assert_raises(ArgumentError) { Nokogiri::HTML5(html, max_attributes: 1) }
+    assert_raises(ArgumentError) { Nokogiri::HTML5(html, max_attributes: 0) }
   end
 
   def test_default_max_attributes
@@ -160,9 +160,9 @@ class TestNokogumbo < Minitest::Test
   def test_fragment_max_attributes
     html = '<div id="i" class="c" title="t"><img src="s" alt="a"></div>'
 
-    assert_raises(ArgumentError ) { Nokogiri::HTML5.fragment(html, max_attributes: 2) }
-    assert_raises(ArgumentError ) { Nokogiri::HTML5.fragment(html, max_attributes: 1) }
-    assert_raises(ArgumentError ) { Nokogiri::HTML5.fragment(html, max_attributes: 0) }
+    assert_raises(ArgumentError) { Nokogiri::HTML5.fragment(html, max_attributes: 2) }
+    assert_raises(ArgumentError) { Nokogiri::HTML5.fragment(html, max_attributes: 1) }
+    assert_raises(ArgumentError) { Nokogiri::HTML5.fragment(html, max_attributes: 0) }
 
     # -1 disables limit
     doc = Nokogiri::HTML5.fragment(html, max_attributes: -1)

--- a/test/test_nokogumbo.rb
+++ b/test/test_nokogumbo.rb
@@ -123,17 +123,9 @@ class TestNokogumbo < Minitest::Test
   def test_max_attributes
     html = '<div id="i" class="c" title="t"><img src="s" alt="a"></div>'
 
-    doc = Nokogiri::HTML5(html, max_attributes: 2)
-    assert_equal({ 'id' => 'i', 'class' => 'c' }, attributes(doc.at_css('div')))
-    assert_equal({ 'src' => 's', 'alt' => 'a' }, attributes(doc.at_css('img')))
-
-    doc = Nokogiri::HTML5(html, max_attributes: 1)
-    assert_equal({ 'id' => 'i' }, attributes(doc.at_css('div')))
-    assert_equal({ 'src' => 's' }, attributes(doc.at_css('img')))
-
-    doc = Nokogiri::HTML5(html, max_attributes: 0)
-    assert_equal({}, attributes(doc.at_css('div')))
-    assert_equal({}, attributes(doc.at_css('img')))
+    assert_raises(ArgumentError ) { Nokogiri::HTML5(html, max_attributes: 2) }
+    assert_raises(ArgumentError ) { Nokogiri::HTML5(html, max_attributes: 1) }
+    assert_raises(ArgumentError ) { Nokogiri::HTML5(html, max_attributes: 0) }
 
     # -1 disables limit
     doc = Nokogiri::HTML5(html, max_attributes: -1)
@@ -147,17 +139,10 @@ class TestNokogumbo < Minitest::Test
     doc = Nokogiri::HTML5(html, max_attributes: 4)
     assert_equal({ 'checked' => '', 'type' => 'checkbox', 'disabled' => '', 'name' => 'cheese' }, attributes(doc.at_css('input')))
 
-    doc = Nokogiri::HTML5(html, max_attributes: 3)
-    assert_equal({ 'checked' => '', 'type' => 'checkbox', 'disabled' => '' }, attributes(doc.at_css('input')))
-
-    doc = Nokogiri::HTML5(html, max_attributes: 2)
-    assert_equal({ 'checked' => '', 'type' => 'checkbox' }, attributes(doc.at_css('input')))
-
-    doc = Nokogiri::HTML5(html, max_attributes: 1)
-    assert_equal({ 'checked' => '' }, attributes(doc.at_css('input')))
-
-    doc = Nokogiri::HTML5(html, max_attributes: 0)
-    assert_equal({}, attributes(doc.at_css('input')))
+    assert_raises(ArgumentError ) { Nokogiri::HTML5(html, max_attributes: 3) }
+    assert_raises(ArgumentError ) { Nokogiri::HTML5(html, max_attributes: 2) }
+    assert_raises(ArgumentError ) { Nokogiri::HTML5(html, max_attributes: 1) }
+    assert_raises(ArgumentError ) { Nokogiri::HTML5(html, max_attributes: 0) }
   end
 
   def test_default_max_attributes
@@ -169,33 +154,15 @@ class TestNokogumbo < Minitest::Test
     # this doesn’t alter performance or end result.
     html = "<div #{attrs.map.with_index { |x, i| "data-#{x}=#{i} data-#{x}=#{i}" }.join(' ')}>hello</div>"
 
-    doc = Nokogiri::HTML5(html)
-    div = doc.at_css('div')
-    assert_equal 'hello', div.text
-    assert_equal   '0', div.attribute("data-#{attrs[0]}").value
-    assert_equal   '1', div.attribute("data-#{attrs[1]}").value
-    assert_equal   '2', div.attribute("data-#{attrs[2]}").value
-    assert_equal '398', div.attribute("data-#{attrs[398]}").value
-    assert_equal '399', div.attribute("data-#{attrs[399]}").value
-    assert_nil div.attribute("data-#{attrs[400]}")
-    assert_nil div.attribute("data-#{attrs[401]}")
-    assert_nil div.attribute("data-#{attrs[402]}")
+    assert_raises(ArgumentError) { Nokogiri::HTML5(html) }
   end
 
   def test_fragment_max_attributes
     html = '<div id="i" class="c" title="t"><img src="s" alt="a"></div>'
 
-    doc = Nokogiri::HTML5.fragment(html, max_attributes: 2)
-    assert_equal({ 'id' => 'i', 'class' => 'c' }, attributes(doc.at_css('div')))
-    assert_equal({ 'src' => 's', 'alt' => 'a' }, attributes(doc.at_css('img')))
-
-    doc = Nokogiri::HTML5.fragment(html, max_attributes: 1)
-    assert_equal({ 'id' => 'i' }, attributes(doc.at_css('div')))
-    assert_equal({ 'src' => 's' }, attributes(doc.at_css('img')))
-
-    doc = Nokogiri::HTML5.fragment(html, max_attributes: 0)
-    assert_equal({}, attributes(doc.at_css('div')))
-    assert_equal({}, attributes(doc.at_css('img')))
+    assert_raises(ArgumentError ) { Nokogiri::HTML5.fragment(html, max_attributes: 2) }
+    assert_raises(ArgumentError ) { Nokogiri::HTML5.fragment(html, max_attributes: 1) }
+    assert_raises(ArgumentError ) { Nokogiri::HTML5.fragment(html, max_attributes: 0) }
 
     # -1 disables limit
     doc = Nokogiri::HTML5.fragment(html, max_attributes: -1)
@@ -212,17 +179,7 @@ class TestNokogumbo < Minitest::Test
     # this doesn’t alter performance or end result.
     html = "<div #{attrs.map.with_index { |x, i| "data-#{x}=#{i} data-#{x}=#{i}" }.join(' ')}>hello</div>"
 
-    doc = Nokogiri::HTML5.fragment(html)
-    div = doc.at_css('div')
-    assert_equal 'hello', div.text
-    assert_equal   '0', div.attribute("data-#{attrs[0]}").value
-    assert_equal   '1', div.attribute("data-#{attrs[1]}").value
-    assert_equal   '2', div.attribute("data-#{attrs[2]}").value
-    assert_equal '398', div.attribute("data-#{attrs[398]}").value
-    assert_equal '399', div.attribute("data-#{attrs[399]}").value
-    assert_nil div.attribute("data-#{attrs[400]}")
-    assert_nil div.attribute("data-#{attrs[401]}")
-    assert_nil div.attribute("data-#{attrs[402]}")
+    assert_raises(ArgumentError) { Nokogiri::HTML5.fragment(html) }
   end
 
   def test_parse_errors

--- a/test/test_nokogumbo.rb
+++ b/test/test_nokogumbo.rb
@@ -120,6 +120,111 @@ class TestNokogumbo < Minitest::Test
     assert_equal ["html", "comment", "html", "comment"], doc.children.map(&:name)
   end
 
+  def test_max_attributes
+    html = '<div id="i" class="c" title="t"><img src="s" alt="a"></div>'
+
+    doc = Nokogiri::HTML5(html, max_attributes: 2)
+    assert_equal({ 'id' => 'i', 'class' => 'c' }, attributes(doc.at_css('div')))
+    assert_equal({ 'src' => 's', 'alt' => 'a' }, attributes(doc.at_css('img')))
+
+    doc = Nokogiri::HTML5(html, max_attributes: 1)
+    assert_equal({ 'id' => 'i' }, attributes(doc.at_css('div')))
+    assert_equal({ 'src' => 's' }, attributes(doc.at_css('img')))
+
+    doc = Nokogiri::HTML5(html, max_attributes: 0)
+    assert_equal({}, attributes(doc.at_css('div')))
+    assert_equal({}, attributes(doc.at_css('img')))
+
+    # -1 disables limit
+    doc = Nokogiri::HTML5(html, max_attributes: -1)
+    assert_equal({ 'id' => 'i', 'class' => 'c', 'title' => 't' }, attributes(doc.at_css('div')))
+    assert_equal({ 'src' => 's', 'alt' => 'a' }, attributes(doc.at_css('img')))
+  end
+
+  def test_max_attributes_boolean
+    html = '<label><input checked type="checkbox" disabled name="cheese"> Cheese</label>'
+
+    doc = Nokogiri::HTML5(html, max_attributes: 4)
+    assert_equal({ 'checked' => '', 'type' => 'checkbox', 'disabled' => '', 'name' => 'cheese' }, attributes(doc.at_css('input')))
+
+    doc = Nokogiri::HTML5(html, max_attributes: 3)
+    assert_equal({ 'checked' => '', 'type' => 'checkbox', 'disabled' => '' }, attributes(doc.at_css('input')))
+
+    doc = Nokogiri::HTML5(html, max_attributes: 2)
+    assert_equal({ 'checked' => '', 'type' => 'checkbox' }, attributes(doc.at_css('input')))
+
+    doc = Nokogiri::HTML5(html, max_attributes: 1)
+    assert_equal({ 'checked' => '' }, attributes(doc.at_css('input')))
+
+    doc = Nokogiri::HTML5(html, max_attributes: 0)
+    assert_equal({}, attributes(doc.at_css('input')))
+  end
+
+  def test_default_max_attributes
+    a = 'a'
+    attrs = 50_000.times.map { x = a.dup; a.succ!; x }
+
+    # <div> contains 50,000 attributes, but default limit is 400. Parsing this would take ages if
+    # we were not enforcing any limit on attributes. All attributes are duplicated to make sure
+    # this doesn’t alter performance or end result.
+    html = "<div #{attrs.map.with_index { |x, i| "data-#{x}=#{i} data-#{x}=#{i}" }.join(' ')}>hello</div>"
+
+    doc = Nokogiri::HTML5(html)
+    div = doc.at_css('div')
+    assert_equal 'hello', div.text
+    assert_equal   '0', div.attribute("data-#{attrs[0]}").value
+    assert_equal   '1', div.attribute("data-#{attrs[1]}").value
+    assert_equal   '2', div.attribute("data-#{attrs[2]}").value
+    assert_equal '398', div.attribute("data-#{attrs[398]}").value
+    assert_equal '399', div.attribute("data-#{attrs[399]}").value
+    assert_nil div.attribute("data-#{attrs[400]}")
+    assert_nil div.attribute("data-#{attrs[401]}")
+    assert_nil div.attribute("data-#{attrs[402]}")
+  end
+
+  def test_fragment_max_attributes
+    html = '<div id="i" class="c" title="t"><img src="s" alt="a"></div>'
+
+    doc = Nokogiri::HTML5.fragment(html, max_attributes: 2)
+    assert_equal({ 'id' => 'i', 'class' => 'c' }, attributes(doc.at_css('div')))
+    assert_equal({ 'src' => 's', 'alt' => 'a' }, attributes(doc.at_css('img')))
+
+    doc = Nokogiri::HTML5.fragment(html, max_attributes: 1)
+    assert_equal({ 'id' => 'i' }, attributes(doc.at_css('div')))
+    assert_equal({ 'src' => 's' }, attributes(doc.at_css('img')))
+
+    doc = Nokogiri::HTML5.fragment(html, max_attributes: 0)
+    assert_equal({}, attributes(doc.at_css('div')))
+    assert_equal({}, attributes(doc.at_css('img')))
+
+    # -1 disables limit
+    doc = Nokogiri::HTML5.fragment(html, max_attributes: -1)
+    assert_equal({ 'id' => 'i', 'class' => 'c', 'title' => 't' }, attributes(doc.at_css('div')))
+    assert_equal({ 'src' => 's', 'alt' => 'a' }, attributes(doc.at_css('img')))
+  end
+
+  def test_fragment_default_max_attributes
+    a = 'a'
+    attrs = 50_000.times.map { x = a.dup; a.succ!; x }
+
+    # <div> contains 50,000 attributes, but default limit is 400. Parsing this would take ages if
+    # we were not enforcing any limit on attributes. All attributes are duplicated to make sure
+    # this doesn’t alter performance or end result.
+    html = "<div #{attrs.map.with_index { |x, i| "data-#{x}=#{i} data-#{x}=#{i}" }.join(' ')}>hello</div>"
+
+    doc = Nokogiri::HTML5.fragment(html)
+    div = doc.at_css('div')
+    assert_equal 'hello', div.text
+    assert_equal   '0', div.attribute("data-#{attrs[0]}").value
+    assert_equal   '1', div.attribute("data-#{attrs[1]}").value
+    assert_equal   '2', div.attribute("data-#{attrs[2]}").value
+    assert_equal '398', div.attribute("data-#{attrs[398]}").value
+    assert_equal '399', div.attribute("data-#{attrs[399]}").value
+    assert_nil div.attribute("data-#{attrs[400]}")
+    assert_nil div.attribute("data-#{attrs[401]}")
+    assert_nil div.attribute("data-#{attrs[402]}")
+  end
+
   def test_parse_errors
     doc = Nokogiri::HTML5("<!DOCTYPE html><html><!-- <!-- --></a>", max_errors: 10)
     assert_equal doc.errors.length, 2
@@ -279,4 +384,7 @@ private
     EOF
   end
 
+  def attributes(element)
+    element.attributes.map { |name, attribute| [name, attribute.value] }.to_h
+  end
 end


### PR DESCRIPTION
Prior to this commit, the time taken to parse elements with an unreasonable number of attributes is non-linear and can lead to excessive memory usage, process hanging and crash.

As a consumer of unsafe HTML, you must enforce some limits on payloads prior to parsing. One easy example is truncating the input string to some max length. However, in a case of extreme number of attributes, there’s no practical way to protect yourself while preserving a decent parsed HTML output (the HTML length isn’t that long by itself). Thus, I believe Nokogumbo should internally enforce a limit after which attributes of a given element will be ignored.

Here’s a script to illustrate the current non-linear work time:

```ruby
require 'bundler/inline'

gemfile do
  source 'https://rubygems.org'
  gem 'nokogumbo'
end

require 'nokogumbo'
require 'benchmark'

Benchmark.bm do |x|
  [
    100,
    1_000,
    5_000,
    10_000,
    25_000,
    50_000,
    75_000,
    # 100_000,
  ].each do |attribute_count|
    html = <<~HTML
      <div
        #{attribute_count.times.map { |x| "fake-attr-#{x}" }.join("\n")}
      >
    HTML

    x.report "#{attribute_count.to_s.rjust(7)} attributes" do
      Nokogiri::HTML5(html)
    end
  end
end
```

```
       user     system      total        real
    100 attributes  0.000251   0.000024   0.000275 (  0.000273)
   1000 attributes  0.005800   0.000065   0.005865 (  0.005875)
   5000 attributes  0.218430   0.003866   0.222296 (  0.308177)
  10000 attributes  1.066644   0.009984   1.076628 (  1.151923)
  25000 attributes  4.366067   0.010645   4.376712 (  4.380356)
  50000 attributes 18.116970   0.029383  18.146353 ( 18.157078)
  75000 attributes 44.749722   0.067786  44.817508 ( 44.843119)
```

With the proposed fix, that script becomes:

```
       user     system      total        real
    100 attributes  0.000249   0.000014   0.000263 (  0.000262)
   1000 attributes  0.001328   0.000001   0.001329 (  0.001328)
   5000 attributes  0.002834   0.000002   0.002836 (  0.002836)
  10000 attributes  0.004665   0.000009   0.004674 (  0.004673)
  25000 attributes  0.010994   0.000026   0.011020 (  0.010997)
  50000 attributes  0.021041   0.000007   0.021048 (  0.021048)
  75000 attributes  0.031382   0.000110   0.031492 (  0.031570)
```

To determine what the value of `Nokogumbo::DEFAULT_MAX_ATTRIBUTES` should be, I looked at lists of attributes to have an idea of how many attributes you could technically use on a given element:

https://github.com/wooorm/html-element-attributes/blob/master/index.json
https://github.com/wooorm/svg-element-attributes/blob/master/index.json
https://github.com/wooorm/aria-attributes/blob/master/index.json

```
Max number of HTML attributes per element: 58
Max number of SVG attributes per element:  107
Max number of ARIA attributes per element: 49
```

([script used](https://gist.github.com/rafbm/0b5c6af5d530688e5326a06751bdc4f4))

I believe all of these can be combined on the same SVG element. This obviously doesn’t consider `data-*` attributes, but these are unlimited in theory. So the value we’ll pick will be arbitrary no matter what. I ended up using `400`, just because we have `Nokogumbo::DEFAULT_MAX_TREE_DEPTH = 400` already. Same number seemed to make some sense.

I assumed we’d want an argument to customize that limit. I went with `:max_attributes` although it could be clearer with `:max_attributes_per_element`. But I don’t think the added length is desirable nor necessary.