### PR TITLE
Fix assertion failure when tag follows UTF-8 BOM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Deprecated
 ### Removed
 ### Fixed
+- Fixed assertion failure when a tag immediately followed the UTF-8 BOM.
 ### Security
 
 ## [2.0.3] - 2020-11-21

--- a/gumbo-parser/src/tokenizer.c
+++ b/gumbo-parser/src/tokenizer.c
@@ -890,9 +890,9 @@ void gumbo_tokenizer_state_init (
 
   mark_tag_state_as_empty(&tokenizer->_tag_state);
 
-  tokenizer->_token_start = text;
   utf8iterator_init(parser, text, text_length, &tokenizer->_input);
   utf8iterator_get_position(&tokenizer->_input, &tokenizer->_token_start_pos);
+  tokenizer->_token_start = utf8iterator_get_char_pointer(&tokenizer->_input);
   doc_type_state_init(parser);
 }
 

--- a/gumbo-parser/test/tokenizer.cc
+++ b/gumbo-parser/test/tokenizer.cc
@@ -4778,5 +4778,13 @@ TEST_F(GumboTokenizerTest, Data_AnythingElse) {
   NextChar(0x05D2);
 }
 
+TEST_F(GumboTokenizerTest, UTF8_BOM) {
+  SetInput("\xEF\xBB\xBF<b>");
+  Next();
+  ASSERT_EQ(GUMBO_TOKEN_START_TAG, token_.type);
+  EXPECT_EQ(GUMBO_TAG_B, token_.v.start_tag.tag);
+  AtEnd();
+}
+
 }  // namespace
 // vim: set sw=2 sts=2 ts=8 et:

--- a/test/test_encoding.rb
+++ b/test/test_encoding.rb
@@ -70,6 +70,12 @@ class TestNokogumbo < Minitest::Test
       assert_equal [], doc.errors
       doc.errors.each { |err| puts(err) }
     end
+
+    def test_tag_after_utf8_bom
+      utf8 = "\uFEFF<b></b>".encode('UTF-8')
+      doc = Nokogiri::HTML5.fragment(utf8, max_errors: 10)
+      assert_equal [], doc.errors
+    end
   end
 
   # https://github.com/rubys/nokogumbo/issues/68


### PR DESCRIPTION
The Gumbo tokenizer assumed that the start of the first token is at the
beginning of the input. This is not the case if the input starts with a
UTF-8 byte-order mark.

This change removes that assumption by asking the iterator itself for
the pointer to the start of the token.

Fixes #157