### PR TITLE
update extconf.rb to use Nokogiri's CPPFLAGS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Support Mageia distros when libxml2/libxslt system libraries are install. #165 (Thank you,
   @pterjan!)
 
+### Improved
+- Update extconf.rb to use Nokogiri v1.11's CPPFLAGS for more reliable installation.
+
+
 ## [2.0.4] - 2020-11-27
 ### Fixed
 - Fixed a bug where `Nokogiri::HTML5.fragment(nil)` would raise an error. Now

--- a/ext/nokogumbo/extconf.rb
+++ b/ext/nokogumbo/extconf.rb
@@ -61,15 +61,21 @@ end
 have_libxml2 = false
 have_ng = false
 
+def windows?
+  ::RUBY_PLATFORM =~ /mingw|mswin/
+end
+
 def modern_nokogiri?
   nokogiri_version = Gem::Version.new(Nokogiri::VERSION)
-  Gem::Requirement.new(">= 1.11.0.rc4").satisfied_by?(nokogiri_version)
+  requirement = windows? ? ">= 1.11.2" : ">= 1.11.0.rc4"
+  Gem::Requirement.new(requirement).satisfied_by?(nokogiri_version)
 end
 
 if !prohibited
   if modern_nokogiri?
     append_cflags(Nokogiri::VERSION_INFO["nokogiri"]["cppflags"])
-    have_libxml2 = have_header('libxml/tree.h')
+    append_ldflags(Nokogiri::VERSION_INFO["nokogiri"]["ldflags"]) # may be nil for nokogiri pre-1.11.2
+    have_libxml2 = have_func("xmlNewDoc", "libxml/tree.h")
   end
 
   if !have_libxml2

--- a/ext/nokogumbo/extconf.rb
+++ b/ext/nokogumbo/extconf.rb
@@ -61,41 +61,54 @@ end
 have_libxml2 = false
 have_ng = false
 
-if !prohibited
-  if Nokogiri::VERSION_INFO.include?('libxml') and
-     Nokogiri::VERSION_INFO['libxml']['source'] == 'packaged'
-    # Nokogiri has libxml2 built in. Find the headers.
-    libxml2_path = File.join(Nokogiri::VERSION_INFO['libxml']['libxml2_path'],
-                             'include/libxml2')
-    if find_header('libxml/tree.h', libxml2_path)
-      have_libxml2 = true
-    else
-      # Unfortunately, some versions of Nokogiri delete these files.
-      # https://github.com/sparklemotion/nokogiri/pull/1788
-      # Try to download them
-      libxml2_path = download_headers
-      unless libxml2_path.nil?
-        have_libxml2 = find_header('libxml/tree.h', libxml2_path)
-      end
-    end
-  else
-    # Nokogiri is compiled with system headers.
-    # Hack to work around broken mkmf on macOS
-    # (https://bugs.ruby-lang.org/issues/14992 fixed now)
-    if RbConfig::MAKEFILE_CONFIG['LIBPATHENV'] == 'DYLD_LIBRARY_PATH'
-      RbConfig::MAKEFILE_CONFIG['LIBPATHENV'] = 'DYLD_FALLBACK_LIBRARY_PATH'
-    end
+def modern_nokogiri?
+  nokogiri_version = Gem::Version.new(Nokogiri::VERSION)
+  Gem::Requirement.new(">= 1.11.0.rc4").satisfied_by?(nokogiri_version)
+end
 
-    pkg_config('libxml-2.0')
-    have_libxml2 = have_library('xml2', 'xmlNewDoc')
+if !prohibited
+  if modern_nokogiri?
+    append_cflags(Nokogiri::VERSION_INFO["nokogiri"]["cppflags"])
+    have_libxml2 = have_header('libxml/tree.h')
   end
+
+  if !have_libxml2
+    if Nokogiri::VERSION_INFO.include?('libxml') and
+       Nokogiri::VERSION_INFO['libxml']['source'] == 'packaged'
+      # Nokogiri has libxml2 built in. Find the headers.
+      libxml2_path = File.join(Nokogiri::VERSION_INFO['libxml']['libxml2_path'],
+                               'include/libxml2')
+      if find_header('libxml/tree.h', libxml2_path)
+        have_libxml2 = true
+      else
+        # Unfortunately, some versions of Nokogiri delete these files.
+        # https://github.com/sparklemotion/nokogiri/pull/1788
+        # Try to download them
+        libxml2_path = download_headers
+        unless libxml2_path.nil?
+          have_libxml2 = find_header('libxml/tree.h', libxml2_path)
+        end
+      end
+    else
+      # Nokogiri is compiled with system headers.
+      # Hack to work around broken mkmf on macOS
+      # (https://bugs.ruby-lang.org/issues/14992 fixed now)
+      if RbConfig::MAKEFILE_CONFIG['LIBPATHENV'] == 'DYLD_LIBRARY_PATH'
+        RbConfig::MAKEFILE_CONFIG['LIBPATHENV'] = 'DYLD_FALLBACK_LIBRARY_PATH'
+      end
+
+      pkg_config('libxml-2.0')
+      have_libxml2 = have_library('xml2', 'xmlNewDoc')
+    end
+  end
+
   if required and !have_libxml2
     abort "libxml2 required but could not be located"
   end
 
+
   if have_libxml2
-    # Find nokogiri.h
-    have_ng = find_header('nokogiri.h', File.join(NG_SPEC.gem_dir, 'ext/nokogiri'))
+    have_ng = have_header('nokogiri.h') || find_header('nokogiri.h', File.join(NG_SPEC.gem_dir, 'ext/nokogiri'))
   end
 end
 
@@ -105,7 +118,6 @@ end
 
 # Symlink gumbo-parser source files.
 ext_dir = File.dirname(__FILE__)
-gumbo_src = File.join(ext_dir, 'gumbo_src')
 
 Dir.chdir(ext_dir) do
   $srcs = Dir['*.c', '../../gumbo-parser/src/*.c']


### PR DESCRIPTION
which are present starting in Nokogiri v1.11.0.rc4.

See https://github.com/sparklemotion/nokogiri/pull/2145 for more information.

With this change, here's what compilation looks like when Nokogiri is built with libxml2:

> /home/flavorjones/.rvm/rubies/ruby-2.7.2/bin/ruby -I. ../../../../ext/nokogumbo/extconf.rb
> checking for whether -I/home/flavorjones/.rvm/gems/ruby-2.7.2/gems/nokogiri-1.11.0.rc3/ext/nokogiri is accepted as CFLAGS... yes
> checking for whether -I/home/flavorjones/.rvm/gems/ruby-2.7.2/gems/nokogiri-1.11.0.rc3/ext/nokogiri/include is accepted as CFLAGS... yes
> checking for whether -I/home/flavorjones/.rvm/gems/ruby-2.7.2/gems/nokogiri-1.11.0.rc3/ext/nokogiri/include/libxml2 is accepted as CFLAGS... yes
> checking for libxml/tree.h... yes
> checking for nokogiri.h... yes
> creating Makefile

and here's what compilation looks like when Nokogiri is _not_ built with libxml2:

> checking for whether -I/home/flavorjones/.rvm/gems/ruby-2.7.2/gems/nokogiri-1.11.0.rc3/ext/nokogiri is accepted as CFLAGS... yes
> checking for libxml/tree.h... no
> checking for nokogiri.h... no
> checking for xmlNewDoc() in -lxml2... yes
> checking for nokogiri.h in /home/flavorjones/.rvm/gems/ruby-2.7.2/gems/nokogiri-1.11.0.rc3/ext/nokogiri... yes
> creating Makefile

In a future update, once we've pinned the Nokogiri dependency to "~> 1.11", we should be able to remove the stanza that looks at `libxml2_path`.