### PR TITLE
fix: only check for the header unless Nokogiri provides LDFLAGS

### DIFF
--- a/ext/nokogumbo/extconf.rb
+++ b/ext/nokogumbo/extconf.rb
@@ -75,7 +75,11 @@ if !prohibited
   if modern_nokogiri?
     append_cflags(Nokogiri::VERSION_INFO["nokogiri"]["cppflags"])
     append_ldflags(Nokogiri::VERSION_INFO["nokogiri"]["ldflags"]) # may be nil for nokogiri pre-1.11.2
-    have_libxml2 = have_func("xmlNewDoc", "libxml/tree.h")
+    have_libxml2 = if Nokogiri::VERSION_INFO["nokogiri"]["ldflags"].empty?
+                     have_header('libxml/tree.h')
+                   else
+                     have_func("xmlNewDoc", "libxml/tree.h")
+                   end
   end
 
   if !have_libxml2


### PR DESCRIPTION
in which case, then we verify that we can resolve libxml symbols.

Related to a41ab09 which checked symbol resolution on both Linux
and Windows; but it fails (and is unnecessary) on Linux, leading to
seeing this at installation:

> checking for xmlNewDoc() in libxml/tree.h... no